### PR TITLE
Decrypte and serve files over separate gateway

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -212,8 +212,15 @@ func (t *TextileNode) StartServices() error {
 		return err
 	}
 
+	// construct decrypting http gateway proxy
+	var gwpErrc <-chan error
+	gwpErrc, err = serveHTTPGatewayProxy(t)
+	if err != nil {
+		return err
+	}
+
 	// merge error channels
-	for err := range merge(gwErrc, gcErrc) {
+	for err := range merge(gwErrc, gcErrc, gwpErrc) {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Super naive approach here to render photos in the desktop app: parse path as ipfs path, get data at that path, try to decrypt. Currently
will fail for non-encrypted paths like the root hash of a photo directory. e.g.,

```
http://localhost:9192/ipfs/QmWkgsT6hT7ja1F7z367X3EcfQzTeZ45nVNMqpzErhSq8d/thumb
http://localhost:9192/ipfs/QmWkgsT6hT7ja1F7z367X3EcfQzTeZ45nVNMqpzErhSq8d/meta
http://localhost:9192/ipfs/QmWkgsT6hT7ja1F7z367X3EcfQzTeZ45nVNMqpzErhSq8d/photo
```
