### PR TITLE
Start and Stop methods for gateway moved to node methods

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -45,6 +45,7 @@ import (
 	"gx/ipfs/Qmej7nf81hi2x2tvjRBF3mcp74sQyuDH4VMYDGd1YtXjb2/go-block-format"
 )
 
+// VERSION is the current version string
 const VERSION = "0.0.1"
 const apiURL = "https://api.textile.io"
 
@@ -61,7 +62,11 @@ const roomRepublishInterval = time.Minute
 const pingRelayInterval = time.Second * 30
 const pingTimeout = 10 * time.Second
 
+// ErrNodeRunning is an error for when node start is called on a running node
 var ErrNodeRunning = errors.New("node is already running")
+
+// ErrNodeNotRunning is an error for  when node stop is called on a nil node
+var ErrNodeNotRunning = errors.New("node is not running")
 
 // TextileNode is the main node interface for textile functionality
 type TextileNode struct {
@@ -357,6 +362,10 @@ func (t *TextileNode) StartServices() (<-chan error, error) {
 
 // Stop the node
 func (t *TextileNode) Stop() error {
+	if t.IpfsNode == nil {
+		return ErrNodeNotRunning
+	}
+
 	repoLockFile := filepath.Join(t.RepoPath, lockfile.LockFile)
 	if err := os.Remove(repoLockFile); err != nil {
 		log.Errorf("error removing lock: %s", err)

--- a/core/core.go
+++ b/core/core.go
@@ -298,19 +298,8 @@ func (t *TextileNode) StartServices() (<-chan error, error) {
 		log.Errorf("error starting gc: %s", err)
 		return nil, err
 	}
-
-	// construct http gateway
-	var gwErrc <-chan error
-	gwErrc, err = serveHTTPGateway(&t.Context)
-	if err != nil {
-		log.Errorf("error starting gateway: %s", err)
-		return nil, err
-	}
-
 	t.ServicesUp = true
-
-	// merge error channels
-	return mergeErrors(gwErrc, gcErrc), nil
+	return gcErrc, nil
 }
 
 // Stop the node

--- a/core/util.go
+++ b/core/util.go
@@ -13,12 +13,9 @@ import (
 	"sync"
 	"time"
 
-	oldcmds "gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/commands"
 	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/core"
-	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/core/corehttp"
 	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/core/corerepo"
 
-	"gx/ipfs/QmRK2LxanhK2gZq6k6R7vk5ZoYZk8ULSSTB7FzDsMUX6CB/go-multiaddr-net"
 	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
 	pstore "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
 	"gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
@@ -60,52 +57,53 @@ func printSwarmAddrs(node *core.IpfsNode) error {
 	return nil
 }
 
+// TODO: remove completely?
 // serveHTTPGateway collects options, creates listener, prints status message and starts serving requests
-func serveHTTPGateway(cctx *oldcmds.Context) (<-chan error, error) {
-	cfg, err := cctx.GetConfig()
-	if err != nil {
-		return nil, fmt.Errorf("ServeHTTPGateway: GetConfig() failed: %s", err)
-	}
-
-	gatewayMaddr, err := ma.NewMultiaddr(cfg.Addresses.Gateway)
-	if err != nil {
-		return nil, fmt.Errorf("ServeHTTPGateway: invalid gateway address: %q (err: %s)", cfg.Addresses.Gateway, err)
-	}
-
-	gwLis, err := manet.Listen(gatewayMaddr)
-	if err != nil {
-		return nil, fmt.Errorf("ServeHTTPGateway: manet.Listen(%s) failed: %s", gatewayMaddr, err)
-	}
-	// we might have listened to /tcp/0 - lets see what we are listing on
-	gatewayMaddr = gwLis.Multiaddr()
-
-	var opts = []corehttp.ServeOption{
-		corehttp.MetricsCollectionOption("gateway"),
-		corehttp.CheckVersionOption(),
-		corehttp.CommandsROOption(*cctx),
-		corehttp.VersionOption(),
-		corehttp.IPNSHostnameOption(),
-		corehttp.GatewayOption(false, "/ipfs", "/ipns"),
-	}
-
-	if len(cfg.Gateway.RootRedirect) > 0 {
-		opts = append(opts, corehttp.RedirectOption("", cfg.Gateway.RootRedirect))
-	}
-
-	node, err := cctx.ConstructNode()
-	if err != nil {
-		return nil, fmt.Errorf("ServeHTTPGateway: ConstructNode() failed: %s", err)
-	}
-
-	errc := make(chan error)
-	go func() {
-		errc <- corehttp.Serve(node, gwLis.NetListener(), opts...)
-		close(errc)
-	}()
-	log.Infof("gateway (readonly) server listening on %s\n", gatewayMaddr)
-
-	return errc, nil
-}
+// func serveHTTPGateway(cctx *oldcmds.Context) (<-chan error, error) {
+// 	cfg, err := cctx.GetConfig()
+// 	if err != nil {
+// 		return nil, fmt.Errorf("ServeHTTPGateway: GetConfig() failed: %s", err)
+// 	}
+//
+// 	gatewayMaddr, err := ma.NewMultiaddr(cfg.Addresses.Gateway)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("ServeHTTPGateway: invalid gateway address: %q (err: %s)", cfg.Addresses.Gateway, err)
+// 	}
+//
+// 	gwLis, err := manet.Listen(gatewayMaddr)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("ServeHTTPGateway: manet.Listen(%s) failed: %s", gatewayMaddr, err)
+// 	}
+// 	// we might have listened to /tcp/0 - lets see what we are listing on
+// 	gatewayMaddr = gwLis.Multiaddr()
+//
+// 	var opts = []corehttp.ServeOption{
+// 		corehttp.MetricsCollectionOption("gateway"),
+// 		corehttp.CheckVersionOption(),
+// 		corehttp.CommandsROOption(*cctx),
+// 		corehttp.VersionOption(),
+// 		corehttp.IPNSHostnameOption(),
+// 		corehttp.GatewayOption(false, "/ipfs", "/ipns"),
+// 	}
+//
+// 	if len(cfg.Gateway.RootRedirect) > 0 {
+// 		opts = append(opts, corehttp.RedirectOption("", cfg.Gateway.RootRedirect))
+// 	}
+//
+// 	node, err := cctx.ConstructNode()
+// 	if err != nil {
+// 		return nil, fmt.Errorf("ServeHTTPGateway: ConstructNode() failed: %s", err)
+// 	}
+//
+// 	errc := make(chan error)
+// 	go func() {
+// 		errc <- corehttp.Serve(node, gwLis.NetListener(), opts...)
+// 		close(errc)
+// 	}()
+// 	log.Infof("gateway (readonly) server listening on %s\n", gatewayMaddr)
+//
+// 	return errc, nil
+// }
 
 // ServeHTTPGatewayProxy starts the secure HTTP gatway proxy server
 func ServeHTTPGatewayProxy(node *TextileNode) (<-chan error, error) {

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -36,7 +36,7 @@ func main() {
 		return
 	}
 
-	// bring the node online
+	// bring the node online and startup the gateway
 	err = textile.Start()
 	if err != nil {
 		astilog.Errorf("start desktop node failed: %s", err)
@@ -52,7 +52,6 @@ func main() {
 	gateway = fmt.Sprintf("https://localhost:%d", gatewayPort)
 
 	// start garbage collection and gateway services
-	// NOTE: on desktop, gateway runs on 8182, decrypting file gateway on 9182
 	errc, err := textile.StartServices()
 	if err != nil {
 		astilog.Errorf("start service error: %s", err)

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -56,17 +56,6 @@ func (w *Wrapper) Start() error {
 	return nil
 }
 
-func (w *Wrapper) StartGateway() error {
-	if w.gatewayRunning {
-		return nil
-	}
-	if _, err := tcore.ServeHTTPGatewayProxy(w.node); err != nil {
-		return err
-	}
-	w.gatewayRunning = true
-	return nil
-}
-
 func (w *Wrapper) Stop() error {
 	return w.node.Stop()
 }

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -38,20 +38,6 @@ func TestWrapper_StartAgain(t *testing.T) {
 	}
 }
 
-func TestWrapper_StartGateway(t *testing.T) {
-	err := wrapper.StartGateway()
-	if err != nil {
-		t.Errorf("start mobile gateway failed: %s", err)
-	}
-}
-
-func TestWrapper_StartGatewayAgain(t *testing.T) {
-	err := wrapper.StartGateway()
-	if err != nil {
-		t.Errorf("start mobile gateway failed: %s", err)
-	}
-}
-
 func TestWrapper_AddPhoto(t *testing.T) {
 	mr, err := wrapper.AddPhoto("testdata/image.jpg", "testdata/thumb.jpg", "default")
 	if err != nil {

--- a/textile.go
+++ b/textile.go
@@ -179,12 +179,13 @@ func main() {
 		return
 	}
 	core.Node = node
+	// start node and https gateway server
 	if err = core.Node.Start(); err != nil {
 		shell.Println(fmt.Errorf("start desktop node failed: %s", err))
 		return
 	}
 
-	// start node http servers and garbage collection
+	// start garbage collection
 	go startServices()
 
 	// join existing rooms
@@ -197,14 +198,16 @@ func main() {
 	shell.Run()
 }
 
-// Start garbage collection and gateway services
-// NOTE: on desktop, gateway runs on 8182, decrypting file gateway on 9192
+// Start garbage collection
 func startServices() {
 	errc, err := core.Node.StartServices()
 	if err != nil {
 		shell.Println(fmt.Errorf("start service error: %s", err))
 		return
 	}
+
+	// TODO: if we want the 'raw' gateway server when running from cmd line
+	// TODO: that can be added here directly (would need to export method)
 
 	for {
 		select {


### PR DESCRIPTION
This should allow us to gracefully stop the gateway server before shutting down