### PR TITLE
feat(central): more node config for server profile

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -287,7 +287,7 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "b68f30494add4df6bd8ef5e82803f308e7f7c59c"
+  revision = "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd"
 
 [[projects]]
   branch = "master"

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -3,6 +3,8 @@ FROM golang:alpine
 WORKDIR /go/src/github.com/textileio/textile-go/central
 COPY . .
 
+RUN apk add --update build-base
+
 RUN go install -v ./...
 
 CMD ["central"]

--- a/core/util.go
+++ b/core/util.go
@@ -24,7 +24,7 @@ import (
 	"gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 )
 
-// PrintSwarmAddrs prints the addresses of the host
+// printSwarmAddrs prints the addresses of the host
 func printSwarmAddrs(node *core.IpfsNode) error {
 	if !node.OnlineMode() {
 		log.Info("swarm not listening, running in offline mode")
@@ -117,6 +117,7 @@ func runGC(ctx context.Context, node *core.IpfsNode) (<-chan error, error) {
 	return errc, nil
 }
 
+// createMnemonic creates a new mnemonic phrase with given entropy
 func createMnemonic(newEntropy func(int) ([]byte, error), newMnemonic func([]byte) (string, error)) (string, error) {
 	entropy, err := newEntropy(256)
 	if err != nil {
@@ -129,6 +130,7 @@ func createMnemonic(newEntropy func(int) ([]byte, error), newMnemonic func([]byt
 	return mnemonic, nil
 }
 
+// identityKeyFromSeed returns a new key identity from a seed
 func identityKeyFromSeed(seed []byte, bits int) ([]byte, error) {
 	hm := hmac.New(sha256.New, []byte("scythian horde"))
 	hm.Write(seed)
@@ -144,6 +146,7 @@ func identityKeyFromSeed(seed []byte, bits int) ([]byte, error) {
 	return encodedKey, nil
 }
 
+// connectToPubSubPeers tries to find other peers that share current subscriptions
 func connectToPubSubPeers(ctx context.Context, n *core.IpfsNode, cid *cid.Cid) {
 	provs := n.Routing.FindProvidersAsync(ctx, cid, 10)
 	wg := &sync.WaitGroup{}
@@ -165,6 +168,7 @@ func connectToPubSubPeers(ctx context.Context, n *core.IpfsNode, cid *cid.Cid) {
 	wg.Wait()
 }
 
+// parsePeerParam takes a peer address string and returns p2p params
 func parsePeerParam(text string) (ma.Multiaddr, peer.ID, error) {
 	// to be replaced with just multiaddr parsing, once ptp is a multiaddr protocol
 	idx := strings.LastIndex(text, "/")

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/op/go-logging"
 
+	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/repo"
 	native "gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/repo/config"
 
 	"gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
@@ -30,6 +31,26 @@ var textileBootstrapAddresses = []string{
 	// relay node 5
 	"/ip4/34.201.54.67/tcp/4001/ipfs/QmTUvaGZqEu7qJw6DuTyhTgiZmZwdp7qN4FD4FFV3TGhjM",
 	"/ip6/2600:1f18:6061:9403:b15e:b223:3c2e:1ee9/tcp/4001/ipfs/QmTUvaGZqEu7qJw6DuTyhTgiZmZwdp7qN4FD4FFV3TGhjM",
+}
+
+// DefaultServerFilters has a list of non-routable IPv4 prefixes
+// according to http://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+var DefaultServerFilters = []string{
+	"/ip4/10.0.0.0/ipcidr/8",
+	"/ip4/100.64.0.0/ipcidr/10",
+	"/ip4/169.254.0.0/ipcidr/16",
+	"/ip4/172.16.0.0/ipcidr/12",
+	"/ip4/192.0.0.0/ipcidr/24",
+	"/ip4/192.0.0.0/ipcidr/29",
+	"/ip4/192.0.0.8/ipcidr/32",
+	"/ip4/192.0.0.170/ipcidr/32",
+	"/ip4/192.0.0.171/ipcidr/32",
+	"/ip4/192.0.2.0/ipcidr/24",
+	"/ip4/192.168.0.0/ipcidr/16",
+	"/ip4/198.18.0.0/ipcidr/15",
+	"/ip4/198.51.100.0/ipcidr/24",
+	"/ip4/203.0.113.0/ipcidr/24",
+	"/ip4/240.0.0.0/ipcidr/4",
 }
 
 func Init(nBitsForKeypair int, isMobile bool) (*native.Config, error) {
@@ -129,6 +150,14 @@ func Init(nBitsForKeypair int, isMobile bool) (*native.Config, error) {
 	}
 
 	return conf, nil
+}
+
+func Update(rep repo.Repo, key string, value interface{}) error {
+	if err := rep.SetConfigKey(key, value); err != nil {
+		log.Errorf("error setting %s: %s", key, err)
+		return err
+	}
+	return nil
 }
 
 // DefaultConnMgrHighWater is the default value for the connection managers

--- a/repo/init.go
+++ b/repo/init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 
 	"github.com/op/go-logging"
 
@@ -15,7 +16,6 @@ import (
 	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/core"
 	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/namesys"
 	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/repo/fsrepo"
-	"time"
 )
 
 const (


### PR DESCRIPTION
- Needed some more control over the IPFS config to properly run our node on a machine with public ip addresses (note: if you run the central server locally via `docker-compose`, it won't be auto-discoverable because MDNS is off)
- Relay cache now just keeps each peer's latest update