### PR TITLE
Split relay and central services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,18 +8,26 @@ jobs:
     steps:
       - checkout
       - run: dep ensure
+      - run: go get -u github.com/kardianos/govendor
       - run:
-          name: vendor central
+          name: install central
           command: |
             cd central
-            go get -u github.com/kardianos/govendor
             govendor init
             govendor add +external
             go install -v ./...
       - run:
-          name: run central and test all
+          name: install relay
+          command: |
+            cd relay
+            govendor init
+            govendor add +external
+            go install -v ./...
+      - run:
+          name: run and test all
           command: |
             central &
+            relay &
             sleep 5
             ./test_compile.sh
           environment:

--- a/central/Dockerfile
+++ b/central/Dockerfile
@@ -3,8 +3,6 @@ FROM golang:alpine
 WORKDIR /go/src/github.com/textileio/textile-go/central
 COPY . .
 
-RUN apk add --update build-base
-
 RUN go install -v ./...
 
 CMD ["central"]

--- a/central/Makefile
+++ b/central/Makefile
@@ -1,0 +1,6 @@
+build:
+	go get github.com/kardianos/govendor
+	govendor init
+	govendor add +external
+	docker-compose build
+	rm -rf vendor

--- a/central/main.go
+++ b/central/main.go
@@ -1,33 +1,14 @@
 package main
 
 import (
-	"context"
-	"io"
 	"os"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/mitchellh/go-homedir"
-	"github.com/op/go-logging"
 
 	"github.com/textileio/textile-go/central/controllers"
 	"github.com/textileio/textile-go/central/dao"
 	"github.com/textileio/textile-go/central/middleware"
-	tcore "github.com/textileio/textile-go/core"
-
-	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/core"
-	"path/filepath"
 )
-
-var log = logging.MustGetLogger("main")
-
-var updateCache = make(map[string]string)
-
-const (
-	relayInterval = time.Second * 30
-)
-
-var relayThread = os.Getenv("RELAY")
 
 func init() {
 	// establish a connection to DB
@@ -45,80 +26,6 @@ func init() {
 }
 
 func main() {
-	go func() {
-		// get home dir
-		hd, err := homedir.Dir()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// create a pubsub relay node
-		config := tcore.NodeConfig{
-			RepoPath:      filepath.Join(hd, ".textile_central"),
-			CentralApiURL: os.Getenv("BIND"),
-			IsServer:      true,
-			LogLevel:      logging.DEBUG,
-			LogFiles:      false,
-			SwarmPort:     "4001",
-		}
-		node, err := tcore.NewNode(config)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// bring it online
-		err = node.Start()
-		if err != nil {
-			log.Fatal(err)
-		}
-		self := node.IpfsNode.Identity.Pretty()
-
-		// create ticker for relaying updates
-		ticker := time.NewTicker(relayInterval)
-		go func() {
-			for range ticker.C {
-				relayLatest(node.IpfsNode)
-			}
-		}()
-
-		// create the subscription
-		sub, err := node.IpfsNode.Floodsub.Subscribe(relayThread)
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Infof("joined room %s as relay buddy\n", relayThread)
-
-		ctx, _ := context.WithCancel(context.Background())
-		for {
-			// unload new message
-			msg, err := sub.Next(ctx)
-			if err == io.EOF || err == context.Canceled {
-				return
-			} else if err != nil {
-				return
-			}
-
-			// unpack message
-			from := msg.GetFrom().Pretty()
-			if from == self {
-				continue
-			}
-			hash := string(msg.GetData())
-
-			// ignore if the latest from this peer has not changed
-			if updateCache[from] == hash {
-				continue
-			}
-
-			// add update to cache
-			updateCache[from] = hash
-			log.Infof("added update %s from %s to relay", hash, from)
-
-			// relay now
-			relayLatest(node.IpfsNode)
-		}
-	}()
-
 	// build http router
 	router := gin.Default()
 	router.GET("/", controllers.Info)
@@ -134,13 +41,4 @@ func main() {
 		v1.GET("/referrals", controllers.ListReferrals)
 	}
 	router.Run(os.Getenv("BIND"))
-}
-
-func relayLatest(ipfs *core.IpfsNode) {
-	for from, update := range updateCache {
-		log.Debugf("relaying update %s from %s", update, from)
-		if err := ipfs.Floodsub.Publish(relayThread, []byte(update)); err != nil {
-			log.Errorf("error relaying update: %s", err)
-		}
-	}
 }

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:alpine
+
+WORKDIR /go/src/github.com/textileio/textile-go/relay
+COPY . .
+
+RUN apk add --update build-base
+
+RUN go install -v ./...
+
+CMD ["relay"]

--- a/relay/Makefile
+++ b/relay/Makefile
@@ -1,0 +1,6 @@
+build:
+	go get github.com/kardianos/govendor
+	govendor init
+	govendor add +external
+	docker-compose build
+	rm -rf vendor

--- a/relay/main.go
+++ b/relay/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/op/go-logging"
+
+	tcore "github.com/textileio/textile-go/core"
+
+	"gx/ipfs/QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn/go-ipfs/core"
+)
+
+var (
+	log         = logging.MustGetLogger("main")
+	updateCache = make(map[string]string)
+	relayThread = os.Getenv("RELAY")
+)
+
+const (
+	relayInterval = time.Second * 30
+)
+
+func main() {
+	// get home dir
+	hd, err := homedir.Dir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// create a pubsub relay node
+	config := tcore.NodeConfig{
+		RepoPath:  filepath.Join(hd, ".textile_central"),
+		IsServer:  true,
+		LogLevel:  logging.DEBUG,
+		LogFiles:  false,
+		SwarmPort: "4001",
+	}
+	node, err := tcore.NewNode(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// bring it online
+	err = node.Start()
+	if err != nil {
+		log.Fatal(err)
+	}
+	self := node.IpfsNode.Identity.Pretty()
+
+	// create ticker for relaying updates
+	ticker := time.NewTicker(relayInterval)
+	go func() {
+		for range ticker.C {
+			relayLatest(node.IpfsNode)
+		}
+	}()
+
+	// create the subscription
+	sub, err := node.IpfsNode.Floodsub.Subscribe(relayThread)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Infof("joined room %s as relay buddy\n", relayThread)
+
+	ctx, _ := context.WithCancel(context.Background())
+	for {
+		// unload new message
+		msg, err := sub.Next(ctx)
+		if err == io.EOF || err == context.Canceled {
+			log.Errorf("subscription ended with known error: %s", err)
+			return
+		} else if err != nil {
+			log.Errorf("subscription ended with unknown error: %s", err)
+			return
+		}
+
+		// unpack message
+		from := msg.GetFrom().Pretty()
+		hash := string(msg.GetData())
+
+		// ignore if from us
+		if from == self {
+			continue
+		}
+
+		// add new updates to cache
+		if updateCache[from] != hash {
+			updateCache[from] = hash
+			log.Infof("added new update %s from %s to relay", hash, from)
+		}
+
+		// relay now
+		relayLatest(node.IpfsNode)
+	}
+}
+
+func relayLatest(ipfs *core.IpfsNode) {
+	for from, update := range updateCache {
+		log.Debugf("relaying update %s from %s", update, from)
+		if err := ipfs.Floodsub.Publish(relayThread, []byte(update)); err != nil {
+			log.Errorf("error relaying update: %s", err)
+		}
+	}
+}

--- a/relay/main.go
+++ b/relay/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/go-homedir"
@@ -88,6 +90,13 @@ func main() {
 			continue
 		}
 
+		// ignore if from another relay
+		tmp := strings.Split(hash, ":")
+		if len(tmp) > 1 && tmp[0] == "relay" {
+			log.Debugf("got update from fellow relay: %s, aborting", from)
+			continue
+		}
+
 		// add new updates to cache
 		if updateCache[from] != hash {
 			updateCache[from] = hash
@@ -102,7 +111,8 @@ func main() {
 func relayLatest(ipfs *core.IpfsNode) {
 	for from, update := range updateCache {
 		log.Debugf("relaying update %s from %s", update, from)
-		if err := ipfs.Floodsub.Publish(relayThread, []byte(update)); err != nil {
+		msg := fmt.Sprintf("relay:%s", update)
+		if err := ipfs.Floodsub.Publish(relayThread, []byte(msg)); err != nil {
 			log.Errorf("error relaying update: %s", err)
 		}
 	}


### PR DESCRIPTION
Also prepends relayed updates with `relay:` so that multiple relays can ignore each others' relays.