### PR TITLE
fix(core): add some timeout ctx where possible

### DIFF
--- a/relay/main.go
+++ b/relay/main.go
@@ -110,10 +110,13 @@ func main() {
 
 func relayLatest(ipfs *core.IpfsNode) {
 	for from, update := range updateCache {
-		log.Debugf("relaying update %s from %s", update, from)
 		msg := fmt.Sprintf("relay:%s", update)
-		if err := ipfs.Floodsub.Publish(relayThread, []byte(msg)); err != nil {
-			log.Errorf("error relaying update: %s", err)
-		}
+		go func() {
+			log.Debug("starting relay...")
+			if err := ipfs.Floodsub.Publish(relayThread, []byte(msg)); err != nil {
+				log.Errorf("error relaying update: %s", err)
+			}
+			log.Debugf("relayed update %s from %s", update, from)
+		}()
 	}
 }


### PR DESCRIPTION
Don't block when publishing or cating files... basically don't block wherever possible and use contexts with timeouts wherever possible. Sadly, you cannot specify a context when publishing... will have to reach out to IPFS to see why these calls hang ever so often (and never stop). 