### PR TITLE
fix(mobile): undeclared variable used when returning error

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -1262,7 +1262,7 @@ func (t *TextileNode) registerGatewayHandler() {
 
 		ci := strings.Join(tmp[2:], "/")
 		if password != t.HashPasses[ci] {
-			log.Debugf("wrong password: %s", ci, t.HashPasses[username])
+			log.Debugf("wrong password: %s", ci, t.HashPasses[ci])
 			w.WriteHeader(401)
 			return
 		}


### PR DESCRIPTION
username not ci