### PR TITLE
feat(relay): allow multi relays in docker swarm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,4 @@ services:
       - "4001:4001"
     environment:
       - RELAY=okaydokay
+      - SWARM_PORT=4001

--- a/relay/main.go
+++ b/relay/main.go
@@ -36,11 +36,11 @@ func main() {
 
 	// create a pubsub relay node
 	config := tcore.NodeConfig{
-		RepoPath:  filepath.Join(hd, ".textile_central"),
+		RepoPath:  filepath.Join(hd, fmt.Sprintf(".relay_%s", relayThread)),
 		IsServer:  true,
 		LogLevel:  logging.DEBUG,
 		LogFiles:  false,
-		SwarmPort: "4001",
+		SwarmPort: os.Getenv("SWARM_PORT"),
 	}
 	node, err := tcore.NewNode(config)
 	if err != nil {


### PR DESCRIPTION
tiny one... relay image just needs to be able to declare its swarm port since we can only have one per