### PR TITLE
fix(mobile): removes timers on mobile, repl. ping w/ connect

### DIFF
--- a/cmd/swarm.go
+++ b/cmd/swarm.go
@@ -12,11 +12,8 @@ import (
 
 	"github.com/textileio/textile-go/core"
 
-	iaddr "gx/ipfs/QmQViVWBHbU6HmYjXcdNq7tVASCNgdg64ZGcauuDkLCivW/go-ipfs-addr"
 	"gx/ipfs/QmSwZMWwFZSUpe5muU2xgTUwppH24KfMwdPXiwbEp2c6G5/go-libp2p-swarm"
 	ma "gx/ipfs/QmWWQ2Txc2c6tqjsBpzg5Ar652cHPGNsQQp2SejkNmkUMb/go-multiaddr"
-	pstore "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
-	"gx/ipfs/QmfAkMSt9Fwzk48QDJecPcwCUjnf2uG7MLnmCGTp4C6ouL/go-ipfs-cmds"
 )
 
 type streamInfo struct {
@@ -158,37 +155,10 @@ func SwarmConnect(c *ishell.Context) {
 	}
 	addrs := c.Args
 
-	if core.Node.IpfsNode.PeerHost == nil {
-		c.Err(errors.New("not online"))
-		return
-	}
-
-	snet, ok := core.Node.IpfsNode.PeerHost.Network().(*swarm.Network)
-	if !ok {
-		c.Err(errors.New("peerhost network was not swarm"))
-		return
-	}
-
-	swrm := snet.Swarm()
-
-	pis, err := peersWithAddresses(addrs)
+	output, err := core.Node.ConnectPeer(addrs)
 	if err != nil {
 		c.Err(err)
 		return
-	}
-
-	output := make([]string, len(pis))
-	for i, pi := range pis {
-		swrm.Backoff().Clear(pi.ID)
-
-		output[i] = "connect " + pi.ID.Pretty()
-
-		err := core.Node.IpfsNode.PeerHost.Connect(core.Node.IpfsNode.Context(), pi)
-		if err != nil {
-			c.Err(fmt.Errorf("%s failure: %s", output[i], err))
-			return
-		}
-		output[i] += " success"
 	}
 
 	// show user their id
@@ -196,34 +166,4 @@ func SwarmConnect(c *ishell.Context) {
 	for _, o := range output {
 		c.Println(red(o))
 	}
-}
-
-// parseAddresses is a function that takes in a slice of string peer addresses
-// (multiaddr + peerid) and returns slices of multiaddrs and peerids.
-func parseAddresses(addrs []string) (iaddrs []iaddr.IPFSAddr, err error) {
-	iaddrs = make([]iaddr.IPFSAddr, len(addrs))
-	for i, saddr := range addrs {
-		iaddrs[i], err = iaddr.ParseString(saddr)
-		if err != nil {
-			return nil, cmds.ClientError("invalid peer address: " + err.Error())
-		}
-	}
-	return
-}
-
-// peersWithAddresses is a function that takes in a slice of string peer addresses
-// (multiaddr + peerid) and returns a slice of properly constructed peers
-func peersWithAddresses(addrs []string) (pis []pstore.PeerInfo, err error) {
-	iaddrs, err := parseAddresses(addrs)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, a := range iaddrs {
-		pis = append(pis, pstore.PeerInfo{
-			ID:    a.ID(),
-			Addrs: []ma.Multiaddr{a.Transport()},
-		})
-	}
-	return pis, nil
 }


### PR DESCRIPTION
Started seeing a lot of ping failures this morning on mobile. If the node can't connect with a common relay node, it's just hosed. So,
- replace ping with connect since once you're for sure connected, everything works perfectly
- _always_ try to connect before publishing anything
- remove tickers on mobile, they just make shutdown too fragile and we don't get much out of them anyway since most people won't be sitting there with the app open forever
- on mobile, publish latest whenever photos are requested

