### PR TITLE
feat(core): start the node offline, use channel for when online

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -46,14 +46,15 @@ func TestNewNode(t *testing.T) {
 }
 
 func TestTextileNode_Start(t *testing.T) {
-	err := node.Start()
+	online, err := node.Start()
 	if err != nil {
 		t.Errorf("start node failed: %s", err)
 	}
+	<-online
 }
 
 func TestTextileNode_StartAgain(t *testing.T) {
-	err := node.Start()
+	_, err := node.Start()
 	if err != ErrNodeRunning {
 		t.Errorf("start node again reported wrong error: %s", err)
 	}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -45,11 +45,12 @@ func main() {
 	}
 
 	// bring the node online and startup the gateway
-	err = textile.Start()
+	online, err := textile.Start()
 	if err != nil {
 		astilog.Errorf("start desktop node failed: %s", err)
 		return
 	}
+	<-online
 
 	// save off the gateway address
 	gateway = fmt.Sprintf("http://localhost%s", textile.GatewayProxy.Addr)

--- a/relay/main.go
+++ b/relay/main.go
@@ -44,10 +44,11 @@ func main() {
 	}
 
 	// bring it online
-	err = node.Start()
+	online, err := node.Start()
 	if err != nil {
 		log.Fatal(err)
 	}
+	<-online
 	self := node.IpfsNode.Identity.Pretty()
 
 	var relay = func() {

--- a/repo/photos/photos.go
+++ b/repo/photos/photos.go
@@ -94,7 +94,7 @@ func Add(n *core.IpfsNode, pk libp2p.PubKey, p *os.File, t *os.File, lc string, 
 
 	// add the image
 	p.Seek(0, 0)
-	pr, err := ImagePathWithoutExif(p)
+	pr, err := GetImageWithoutExif(p)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,7 +108,7 @@ func Add(n *core.IpfsNode, pk libp2p.PubKey, p *os.File, t *os.File, lc string, 
 	}
 
 	// add the thumbnail
-	tr, err := ImagePathWithoutExif(t)
+	tr, err := GetImageWithoutExif(t)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/repo/photos/util.go
+++ b/repo/photos/util.go
@@ -14,11 +14,11 @@ import (
 	"github.com/rwcarlsen/goexif/exif"
 )
 
-// ImagePathWithoutExif makes a copy of image (jpg,png or gif) and applies
+// GetImageWithoutExif makes a copy of image (jpg,png or gif) and applies
 // all necessary operation to reverse its orientation to 1
 // The result is a image with corrected orientation and without
 // exif data.
-func ImagePathWithoutExif(ifile *os.File) (*bytes.Buffer, error) {
+func GetImageWithoutExif(ifile *os.File) (*bytes.Buffer, error) {
 	var img image.Image
 	var err error
 	writer := &bytes.Buffer{}
@@ -52,7 +52,7 @@ func ImagePathWithoutExif(ifile *os.File) (*bytes.Buffer, error) {
 	if x != nil {
 		orient, _ := x.Get(exif.Orientation)
 		if orient != nil {
-			log.Infof("%s had orientation %s", ifile.Name(), orient.String())
+			log.Debugf("%s had orientation %s", ifile.Name(), orient.String())
 			img = reverseOrientation(img, orient.String())
 		} else {
 			log.Errorf("%s had no orientation - implying 1", ifile.Name())

--- a/textile.go
+++ b/textile.go
@@ -234,9 +234,11 @@ func main() {
 
 func start(shell *ishell.Shell) error {
 	// start node
-	if err := core.Node.Start(); err != nil {
+	online, err := core.Node.Start()
+	if err != nil {
 		return err
 	}
+	<-online
 
 	// start garbage collection
 	// TODO: see method todo before enabling


### PR DESCRIPTION
More complicated, but way better experience. The basic idea is to first start the textile node (create and IPFS node) in offline mode, then kickoff a different goroutine that constructs a new node IPFS node in online mode... when it's ready, swap out the offline node.

@andrewxhill FYI seeing a bunch of wrong password errors in textile.log, but nothing seems to be visibly wrong looking at the UI. Not sure if this is related to this change or your progressive loading branch, since that's what I've been testing this with.