### PR TITLE
feat(core): adds on disk version and brute migration

### DIFF
--- a/repo/datastore.go
+++ b/repo/datastore.go
@@ -23,9 +23,8 @@ type Queryable interface {
 
 type ConfigStore interface {
 	Init(password string) error
-	Configure(created time.Time, version string) error
+	Configure(created time.Time) error
 	GetCreationDate() (time.Time, error)
-	GetVersion() (string, error)
 	IsEncrypted() bool
 }
 

--- a/repo/db/config_test.go
+++ b/repo/db/config_test.go
@@ -20,7 +20,7 @@ func setup() {
 	os.MkdirAll(path.Join("./", "datastore"), os.ModePerm)
 	testDB, _ = Create("", "LetMeIn")
 	testDB.config.Init("LetMeIn")
-	testDB.config.Configure(time.Now(), "boom")
+	testDB.config.Configure(time.Now())
 }
 
 func teardown() {
@@ -37,16 +37,6 @@ func TestConfigDB_GetCreationDate(t *testing.T) {
 	_, err := testDB.config.GetCreationDate()
 	if err != nil {
 		t.Error(err)
-	}
-}
-
-func TestConfigDB_GetVersion(t *testing.T) {
-	sv, err := testDB.config.GetVersion()
-	if err != nil {
-		t.Error(err)
-	}
-	if sv != "boom" {
-		t.Error("version mismatch")
 	}
 }
 


### PR DESCRIPTION
The on-disk version string (on disk via a normal file, rather) is needed so we can check the version _before_ spinning up the sqlite datastore.