### PR TITLE
Mobile API tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ build_desktop:
 	$(MAKE) -C ./desktop build
 
 ios_framework:
-	CGO_CFLAGS_ALLOW='-fmodules|-fblocks' gomobile bind -target=ios/arm64 github.com/textileio/textile-go/mobile github.com/textileio/textile-go/net
+	CGO_CFLAGS_ALLOW='-fmodules|-fblocks' gomobile bind -target=ios/arm64 github.com/textileio/textile-go/mobile
 	# cp -r Mobile.framework ~/github/textileio/textile-mobile/ios/
 
 android_framework:
-	gomobile bind -target=android -o textilego.aar github.com/textileio/textile-go/mobile github.com/textileio/textile-go/net
+	gomobile bind -target=android -o textilego.aar github.com/textileio/textile-go/mobile
 	# cp -r textilego.aar ~/github/textileio/textile-mobile/android/textilego/
 
 P_TIMESTAMP = Mgoogle/protobuf/timestamp.proto=github.com/golang/protobuf/ptypes/timestamp

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -9,15 +9,17 @@ import (
 	"testing"
 )
 
+var repo = "testdata/.textile"
+
 var node *TextileNode
 
 func TestNewNode(t *testing.T) {
-	os.RemoveAll("testdata/.ipfs")
+	os.RemoveAll(repo)
 	config := NodeConfig{
 		LogLevel: logging.DEBUG,
 		LogFiles: false,
 		WalletConfig: wallet.Config{
-			RepoPath:   "testdata/.ipfs",
+			RepoPath:   repo,
 			CentralAPI: util.CentralApiURL,
 			IsMobile:   false,
 		},

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -26,11 +26,8 @@ type Event struct {
 // newEvent transforms an event name and structured data in Event
 func newEvent(name string, payload map[string]interface{}) *Event {
 	event := &Event{Name: name}
-	jsonb, err := json.Marshal(payload)
-	if err != nil {
-		log.Errorf("error creating event data json: %s", err)
-	}
-	event.Payload = string(jsonb)
+	jsn, _ := toJSON(payload)
+	event.Payload = jsn
 	return event
 }
 
@@ -93,8 +90,10 @@ type Blocks struct {
 	Items []BlockItem `json:"items"`
 }
 
-// tmp while central does not proxy the remote ipfs cluster
-const RemoteIPFSApi = "https://ipfs.textile.io/api/v0"
+// PinRequests is a wrapper around multiple PinRequests
+type PinRequests struct {
+	Items []net.PinRequest `json:"items"`
+}
 
 // Create a gomobile compatible wrapper around TextileNode
 func NewNode(config *NodeConfig, messenger Messenger) (*Mobile, error) {
@@ -218,13 +217,12 @@ func (m *Mobile) Threads() (string, error) {
 		threads.Items = append(threads.Items, item)
 	}
 
-	jsonb, err := json.Marshal(threads)
+	// build json
+	jsn, err := toJSON(threads)
 	if err != nil {
-		log.Errorf("error marshaling json: %s", err)
 		return "", err
 	}
-
-	return string(jsonb), nil
+	return jsn, nil
 }
 
 // AddThread adds a new thread with the given name
@@ -237,23 +235,22 @@ func (m *Mobile) AddThread(name string, mnemonic string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	// subscribe to updates
+	go m.subscribe(thrd)
+
+	// build json
 	peers := thrd.Peers("", -1)
 	item := ThreadItem{
 		Id:    thrd.Id,
 		Name:  thrd.Name,
 		Peers: len(peers),
 	}
-
-	jsonb, err := json.Marshal(item)
+	jsn, err := toJSON(item)
 	if err != nil {
-		log.Errorf("error marshaling json: %s", err)
 		return "", err
 	}
-
-	// subscribe to updates
-	go m.subscribe(thrd)
-
-	return string(jsonb), nil
+	return jsn, nil
 }
 
 // RemoveThread call core RemoveDevice
@@ -269,13 +266,12 @@ func (m *Mobile) Devices() (string, error) {
 		devices.Items = append(devices.Items, item)
 	}
 
-	jsonb, err := json.Marshal(devices)
+	// build json
+	jsn, err := toJSON(devices)
 	if err != nil {
-		log.Errorf("error marshaling json: %s", err)
 		return "", err
 	}
-
-	return string(jsonb), nil
+	return jsn, nil
 }
 
 // AddDevice calls core AddDevice
@@ -296,31 +292,30 @@ func (m *Mobile) RemoveDevice(name string) error {
 	return tcore.Node.Wallet.RemoveDevice(name)
 }
 
-// AddPhoto adds a photo by path and shares it to the default thread
-func (m *Mobile) AddPhoto(path string, threadName string, caption string) (*net.MultipartRequest, error) {
+// AddPhoto adds a photo by path and shares it to a thread
+func (m *Mobile) AddPhoto(path string, threadName string, caption string) (string, error) {
 	_, thrd := tcore.Node.Wallet.GetThreadByName(threadName)
 	if thrd == nil {
-		return nil, errors.New(fmt.Sprintf("could not find thread: %s", threadName))
+		return "", errors.New(fmt.Sprintf("could not find thread: %s", threadName))
 	}
 	added, err := tcore.Node.Wallet.AddPhoto(path)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	shared, err := thrd.AddPhoto(added.Id, caption, added.Key)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	// pin to remote
-	url := fmt.Sprintf("%s/add?wrap-with-directory=true", RemoteIPFSApi)
-	status, err := shared.RemoteRequest.Send(url)
+	// build json
+	requests := PinRequests{}
+	requests.Items = append(requests.Items, *added.RemoteRequest)
+	requests.Items = append(requests.Items, *shared.RemoteRequest)
+	jsn, err := toJSON(requests)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	log.Debugf("pinned block to remote (status %s)", status)
-
-	// let the OS handle the large upload
-	return added.RemoteRequest, nil
+	return jsn, nil
 }
 
 // SharePhoto adds an existing photo to a new thread
@@ -348,15 +343,14 @@ func (m *Mobile) SharePhoto(id string, threadName string, caption string) (strin
 		return "", err
 	}
 
-	// pin to remote
-	url := fmt.Sprintf("%s/add?wrap-with-directory=true", RemoteIPFSApi)
-	status, err := shared.RemoteRequest.Send(url)
+	// build json
+	requests := PinRequests{}
+	requests.Items = append(requests.Items, *shared.RemoteRequest)
+	jsn, err := toJSON(requests)
 	if err != nil {
 		return "", err
 	}
-	log.Debugf("pinned block to remote (status %s)", status)
-
-	return shared.Id, nil
+	return jsn, nil
 }
 
 // PhotoBlocks returns thread photo blocks with json encoding
@@ -366,11 +360,7 @@ func (m *Mobile) PhotoBlocks(offsetId string, limit int, threadName string) (str
 		return "", errors.New(fmt.Sprintf("thread not found: %s", threadName))
 	}
 
-	// use this opportunity to post head
-	if tcore.Node.Wallet.Online() {
-		go thrd.PostHead()
-	}
-
+	// build json
 	blocks := &Blocks{}
 	for _, b := range thrd.Blocks(offsetId, limit, repo.PhotoBlock) {
 		blocks.Items = append(blocks.Items, BlockItem{
@@ -381,13 +371,11 @@ func (m *Mobile) PhotoBlocks(offsetId string, limit int, threadName string) (str
 			Date:    b.Date,
 		})
 	}
-	jsonb, err := json.Marshal(blocks)
+	jsn, err := toJSON(blocks)
 	if err != nil {
-		log.Errorf("error marshaling json: %s", err)
 		return "", err
 	}
-
-	return string(jsonb), nil
+	return jsn, nil
 }
 
 // GetBlockData calls GetBlockDataBase64 on a thread
@@ -441,4 +429,14 @@ func (m *Mobile) subscribe(thrd *thread.Thread) {
 			}))
 		}
 	}
+}
+
+// toJSON returns a json string and logs errors
+func toJSON(any interface{}) (string, error) {
+	jsonb, err := json.Marshal(any)
+	if err != nil {
+		log.Errorf("error marshaling json: %s", err)
+		return "", err
+	}
+	return string(jsonb), nil
 }

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -17,6 +17,8 @@ type TestMessenger struct {
 
 func (tm *TestMessenger) Notify(event *Event) {}
 
+var repo = "testdata/.textile"
+
 var mobile *Mobile
 var addedPhotoId string
 var sharedBlockId string
@@ -26,9 +28,9 @@ var cpassword = ksuid.New().String()
 var cemail = ksuid.New().String() + "@textile.io"
 
 func TestNewTextile(t *testing.T) {
-	os.RemoveAll("testdata/.ipfs")
+	os.RemoveAll(repo)
 	config := &NodeConfig{
-		RepoPath:      "testdata/.ipfs",
+		RepoPath:      repo,
 		CentralApiURL: util.CentralApiURL,
 		LogLevel:      "DEBUG",
 	}
@@ -212,20 +214,18 @@ func TestMobile_RemoveDevice(t *testing.T) {
 }
 
 func TestMobile_AddPhoto(t *testing.T) {
-	mr, err := mobile.AddPhoto("testdata/image.jpg", "default", "howdy")
+	mrs, err := mobile.AddPhoto("testdata/image.jpg", "default", "howdy")
 	if err != nil {
 		t.Errorf("add photo failed: %s", err)
 		return
 	}
-	if len(mr.Boundary) == 0 {
-		t.Errorf("add photo got bad hash")
+	reqs := PinRequests{}
+	json.Unmarshal([]byte(mrs), &reqs)
+	if len(reqs.Items) != 2 {
+		t.Errorf("add photo got bad pin requests")
 		return
 	}
-	addedPhotoId = mr.Boundary
-	err = os.Remove("testdata/.ipfs/tmp/" + mr.Boundary)
-	if err != nil {
-		t.Errorf("error unlinking test multipart file: %s", err)
-	}
+	addedPhotoId = reqs.Items[0].Boundary
 }
 
 func TestMobile_SharePhoto(t *testing.T) {
@@ -234,15 +234,18 @@ func TestMobile_SharePhoto(t *testing.T) {
 		return
 	}
 	caption := "rasputin's eyes"
-	var err error
-	sharedBlockId, err = mobile.SharePhoto(addedPhotoId, "test", caption)
+	mrs, err := mobile.SharePhoto(addedPhotoId, "test", caption)
 	if err != nil {
 		t.Errorf("share photo failed: %s", err)
 		return
 	}
-	if len(sharedBlockId) == 0 {
-		t.Errorf("share photo got bad id")
+	reqs := PinRequests{}
+	json.Unmarshal([]byte(mrs), &reqs)
+	if len(reqs.Items) != 1 {
+		t.Errorf("share photo got bad pin requests")
+		return
 	}
+	sharedBlockId = reqs.Items[0].Boundary
 }
 
 func TestMobile_PhotoBlocks(t *testing.T) {

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -108,18 +108,18 @@ func TestMobile_GetAccessToken(t *testing.T) {
 }
 
 func TestMobile_AddThread(t *testing.T) {
-	id, err := mobile.AddThread("default", "")
+	item, err := mobile.AddThread("default", "")
 	if err != nil {
 		t.Errorf("add thread failed: %s", err)
 	}
-	if id == "" {
-		t.Error("add thread bad id")
+	if item == "" {
+		t.Error("add thread bad result")
 	}
 }
 
 func TestMobile_AddThreadAgain(t *testing.T) {
-	if _, err := mobile.AddThread("default", ""); err != nil {
-		t.Errorf("add thread again failed: %s", err)
+	if _, err := mobile.AddThread("default", ""); err == nil {
+		t.Errorf("add thread again should fail: %s", err)
 	}
 }
 

--- a/net/multipart.go
+++ b/net/multipart.go
@@ -9,17 +9,17 @@ import (
 
 var nl = "\r\n"
 
-type MultipartRequest struct {
+type PinRequest struct {
 	Boundary    string
 	PayloadPath string
 }
 
-func (m *MultipartRequest) Init(dir string, boundary string) {
+func (m *PinRequest) Init(dir string, boundary string) {
 	m.Boundary = boundary
 	m.PayloadPath = filepath.Join(dir, boundary)
 }
 
-func (m *MultipartRequest) AddFile(b []byte, fname string) error {
+func (m *PinRequest) AddFile(b []byte, fname string) error {
 	// create file if not yet exists
 	file, err := os.OpenFile(m.PayloadPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
@@ -50,7 +50,7 @@ func (m *MultipartRequest) AddFile(b []byte, fname string) error {
 	return nil
 }
 
-func (m *MultipartRequest) Finish() error {
+func (m *PinRequest) Finish() error {
 	// open file, will error if not first inited
 	file, err := os.OpenFile(m.PayloadPath, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
@@ -70,7 +70,7 @@ func (m *MultipartRequest) Finish() error {
 	return nil
 }
 
-func (m *MultipartRequest) Send(url string) (string, error) {
+func (m *PinRequest) Send(url string) (string, error) {
 	// open file, will error if not first inited
 	file, err := os.Open(m.PayloadPath)
 	if err != nil {

--- a/wallet/model/model.go
+++ b/wallet/model/model.go
@@ -22,7 +22,7 @@ type FileMetadata struct {
 type AddResult struct {
 	Id            string
 	Key           []byte
-	RemoteRequest *net.MultipartRequest
+	RemoteRequest *net.PinRequest
 }
 
 type PhotoMetadata struct {

--- a/wallet/thread/thread.go
+++ b/wallet/thread/thread.go
@@ -274,7 +274,7 @@ func (t *Thread) AddPhoto(id string, caption string, key []byte) (*model.AddResu
 	go t.PostHead()
 
 	// create and init a new multipart request
-	request := &net.MultipartRequest{}
+	request := &net.PinRequest{}
 	request.Init(filepath.Join(t.repoPath, "tmp"), bid)
 
 	// add files to request

--- a/wallet/thread_test.go
+++ b/wallet/thread_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-var trepo = "testdata/.ipfs1"
+var trepo = "testdata/.textile1"
 
 var twallet *Wallet
 var wonline <-chan struct{}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -762,7 +762,7 @@ func (w *Wallet) AddPhoto(path string) (*model.AddResult, error) {
 	id := dir.Cid().Hash().B58String()
 
 	// create and init a new multipart request
-	request := &net.MultipartRequest{}
+	request := &net.PinRequest{}
 	request.Init(filepath.Join(w.repoPath, "tmp"), id)
 
 	// add files to request

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/textileio/textile-go/wallet"
 )
 
-var repo = "testdata/.ipfs"
+var repo = "testdata/.textile"
 
 var wallet *Wallet
 var addedId string
@@ -203,10 +203,6 @@ func TestWallet_AddPhoto(t *testing.T) {
 		t.Errorf("add photo got bad id")
 	}
 	addedId = added.Id
-	err = os.Remove("testdata/.ipfs/tmp/" + addedId)
-	if err != nil {
-		t.Errorf("error unlinking test multipart file: %s", err)
-	}
 }
 
 func TestWallet_GetBlock(t *testing.T) {


### PR DESCRIPTION
- add and share photo return json string with list of pin requests (prev. `net.MultipartRequest`)
- use a `BlockItem` to be consistent with `ThreadItem` and `DeviceItem`
- add thread returns an object, not just id (`ThreadItem`) 