### PR TITLE
feat(photos): index photo metadata

### DIFF
--- a/cmd/photos.go
+++ b/cmd/photos.go
@@ -180,7 +180,7 @@ func GetPhoto(c *ishell.Context) {
 	c.Println(blue("saved to " + path))
 }
 
-func CatPhotoMetadata(c *ishell.Context) {
+func GetPhotoMetadata(c *ishell.Context) {
 	if len(c.Args) == 0 {
 		c.Err(errors.New("missing photo id"))
 		return
@@ -238,14 +238,9 @@ func IgnorePhoto(c *ishell.Context) {
 	}
 	id := c.Args[0]
 
-	block, err := core.Node.Wallet.GetBlock(id)
+	block, thrd, err := getBlockAndThreadForDataId(id)
 	if err != nil {
 		c.Err(err)
-		return
-	}
-	_, thrd := core.Node.Wallet.GetThread(block.ThreadId)
-	if thrd == nil {
-		c.Err(errors.New(fmt.Sprintf("could not find thread %s", block.ThreadId)))
 		return
 	}
 
@@ -259,6 +254,9 @@ func getBlockAndThreadForDataId(dataId string) (*repo.Block, *thread.Thread, err
 	block, err := core.Node.Wallet.GetBlockByDataId(dataId)
 	if err != nil {
 		return nil, nil, err
+	}
+	if block.Type != repo.PhotoBlock {
+		return nil, nil, errors.New("not a photo block, aborting")
 	}
 	_, thrd := core.Node.Wallet.GetThread(block.ThreadId)
 	if thrd == nil {

--- a/mobile/photos.go
+++ b/mobile/photos.go
@@ -2,6 +2,7 @@ package mobile
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/textileio/textile-go/core"
@@ -14,11 +15,12 @@ import (
 
 // Photo is a simple meta data wrapper around a photo block
 type Photo struct {
-	Id       string    `json:"id"`
-	Date     time.Time `json:"date"`
-	AuthorId string    `json:"author_id"`
-	Caption  string    `json:"caption"`
-	Username string    `json:"username"`
+	Id       string              `json:"id"`
+	Date     time.Time           `json:"date"`
+	AuthorId string              `json:"author_id"`
+	Caption  string              `json:"caption"`
+	Username string              `json:"username"`
+	Metadata *util.PhotoMetadata `json:"metadata,omitempty"`
 }
 
 // Photos is a wrapper around a list of photos
@@ -98,6 +100,7 @@ func (m *Mobile) GetPhotos(offsetId string, limit int, threadId string) (string,
 	btype := repo.PhotoBlock
 	for _, b := range thrd.Blocks(offsetId, limit, &btype) {
 		var caption, username string
+		var metadata *util.PhotoMetadata
 		if b.DataCaptionCipher != nil {
 			captionb, err := thrd.Decrypt(b.DataCaptionCipher)
 			if err != nil {
@@ -112,6 +115,15 @@ func (m *Mobile) GetPhotos(offsetId string, limit int, threadId string) (string,
 			}
 			username = string(usernameb)
 		}
+		if b.DataMetadataCipher != nil {
+			metadatab, err := thrd.Decrypt(b.DataMetadataCipher)
+			if err != nil {
+				return "", err
+			}
+			if err := json.Unmarshal(metadatab, &metadata); err != nil {
+				log.Warningf("unmarshal photo metadata failed: %s", err)
+			}
+		}
 		authorId, err := util.IdFromEncodedPublicKey(b.AuthorPk)
 		if err != nil {
 			return "", err
@@ -122,6 +134,7 @@ func (m *Mobile) GetPhotos(offsetId string, limit int, threadId string) (string,
 			Caption:  caption,
 			AuthorId: authorId.Pretty(),
 			Username: username,
+			Metadata: metadata,
 		})
 	}
 

--- a/mobile/photos.go
+++ b/mobile/photos.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/textileio/textile-go/core"
+	"github.com/textileio/textile-go/crypto"
 	"github.com/textileio/textile-go/repo"
 	"github.com/textileio/textile-go/util"
 	libp2pc "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
@@ -116,7 +117,11 @@ func (m *Mobile) GetPhotos(offsetId string, limit int, threadId string) (string,
 			username = string(usernameb)
 		}
 		if b.DataMetadataCipher != nil {
-			metadatab, err := thrd.Decrypt(b.DataMetadataCipher)
+			key, err := thrd.Decrypt(b.DataKeyCipher)
+			if err != nil {
+				return "", err
+			}
+			metadatab, err := crypto.DecryptAES(b.DataMetadataCipher, key)
 			if err != nil {
 				return "", err
 			}

--- a/repo/db/blocks.go
+++ b/repo/db/blocks.go
@@ -24,7 +24,7 @@ func (c *BlockDB) Add(block *repo.Block) error {
 	if err != nil {
 		return err
 	}
-	stm := `insert into blocks(id, date, parents, threadId, authorPk, type, dataId, dataKeyCipher, dataCaptionCipher, dataUsernameCipher) values(?,?,?,?,?,?,?,?,?,?)`
+	stm := `insert into blocks(id, date, parents, threadId, authorPk, type, dataId, dataKeyCipher, dataCaptionCipher, dataUsernameCipher, dataMetadataCipher) values(?,?,?,?,?,?,?,?,?,?,?)`
 	stmt, err := tx.Prepare(stm)
 	if err != nil {
 		log.Errorf("error in tx prepare: %s", err)
@@ -42,6 +42,7 @@ func (c *BlockDB) Add(block *repo.Block) error {
 		block.DataKeyCipher,
 		block.DataCaptionCipher,
 		block.DataUsernameCipher,
+		block.DataMetadataCipher,
 	)
 	if err != nil {
 		tx.Rollback()
@@ -126,8 +127,8 @@ func (c *BlockDB) handleQuery(stm string) []repo.Block {
 	for rows.Next() {
 		var id, parents, threadId, authorPk, dataId string
 		var dateInt, typeInt int
-		var dataKeyCipher, dataCaptionCipher, dataUsernameCipher []byte
-		if err := rows.Scan(&id, &dateInt, &parents, &threadId, &authorPk, &typeInt, &dataId, &dataKeyCipher, &dataCaptionCipher, &dataUsernameCipher); err != nil {
+		var dataKeyCipher, dataCaptionCipher, dataUsernameCipher, dataMetadataCipher []byte
+		if err := rows.Scan(&id, &dateInt, &parents, &threadId, &authorPk, &typeInt, &dataId, &dataKeyCipher, &dataCaptionCipher, &dataUsernameCipher, &dataMetadataCipher); err != nil {
 			log.Errorf("error in db scan: %s", err)
 			continue
 		}
@@ -142,6 +143,7 @@ func (c *BlockDB) handleQuery(stm string) []repo.Block {
 			DataKeyCipher:      dataKeyCipher,
 			DataCaptionCipher:  dataCaptionCipher,
 			DataUsernameCipher: dataUsernameCipher,
+			DataMetadataCipher: dataMetadataCipher,
 		}
 		ret = append(ret, block)
 	}

--- a/repo/db/blocks_test.go
+++ b/repo/db/blocks_test.go
@@ -49,6 +49,7 @@ func TestBlockDB_Put(t *testing.T) {
 		DataKeyCipher:      key,
 		DataCaptionCipher:  []byte("xxx"),
 		DataUsernameCipher: []byte("un"),
+		DataMetadataCipher: []byte("{}"),
 	})
 	if err != nil {
 		t.Error(err)
@@ -106,6 +107,7 @@ func TestBlockDB_List(t *testing.T) {
 		DataKeyCipher:      key,
 		DataCaptionCipher:  []byte("xxx"),
 		DataUsernameCipher: []byte("un"),
+		DataMetadataCipher: []byte("{}"),
 	})
 	if err != nil {
 		t.Error(err)
@@ -130,6 +132,7 @@ func TestBlockDB_List(t *testing.T) {
 		DataKeyCipher:      key,
 		DataCaptionCipher:  []byte("xxx"),
 		DataUsernameCipher: []byte("un"),
+		DataMetadataCipher: []byte("{}"),
 	})
 	if err != nil {
 		t.Error(err)
@@ -181,6 +184,7 @@ func TestBlockDB_Count(t *testing.T) {
 		DataKeyCipher:      key,
 		DataCaptionCipher:  []byte("xxx"),
 		DataUsernameCipher: []byte("un"),
+		DataMetadataCipher: []byte("{}"),
 	})
 	if err != nil {
 		t.Error(err)

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -152,7 +152,7 @@ func initDatabaseTables(db *sql.DB, password string) error {
     create table devices (id text primary key not null, name text not null);
     create table peers (row text primary key not null, id text not null, pk blob not null, threadId text not null);
     create unique index peer_threadId_id on peers (threadId, id);
-    create table blocks (id text primary key not null, date integer not null, parents text not null, threadId text not null, authorPk text not null, type integer not null, dataId text, dataKeyCipher blob, dataCaptionCipher blob, dataUsernameCipher blob);
+    create table blocks (id text primary key not null, date integer not null, parents text not null, threadId text not null, authorPk text not null, type integer not null, dataId text, dataKeyCipher blob, dataCaptionCipher blob, dataUsernameCipher blob, dataMetadataCipher blob);
     create index block_dataId on blocks (dataId);
     create index block_threadId_type_date on blocks (threadId, type, date);
     create table offlinemessages (url text primary key not null, date integer, message blob);

--- a/repo/init.go
+++ b/repo/init.go
@@ -20,7 +20,7 @@ var log = logging.MustGetLogger("repo")
 
 var ErrRepoExists = errors.New("repo not empty, reinitializing would overwrite your keys")
 
-const repover = "1"
+const repover = "2"
 
 func DoInit(repoRoot string, version string, mnemonic *string, initDB func(string) error, initConfig func(time.Time) error) (string, error) {
 	if err := checkWriteable(repoRoot); err != nil {

--- a/repo/migrations.go
+++ b/repo/migrations.go
@@ -15,6 +15,7 @@ type Migration interface {
 
 var migrations = []Migration{
 	migs.Migration000{},
+	migs.Migration001{},
 }
 
 // migrateUp looks at the currently active migration version and will migrate all the way up (applying all up migrations)
@@ -23,7 +24,7 @@ func migrateUp(repoPath, dbPassword string, testnet bool) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	} else if err != nil && os.IsNotExist(err) {
-		version = []byte("000")
+		version = []byte("0")
 	}
 	v, err := strconv.Atoi(string(version[0]))
 	if err != nil {

--- a/repo/migrations/migration001.go
+++ b/repo/migrations/migration001.go
@@ -1,0 +1,61 @@
+package migrations
+
+import (
+	"database/sql"
+	_ "github.com/mutecomm/go-sqlcipher"
+	"os"
+	"path"
+)
+
+type Migration001 struct{}
+
+func (Migration001) Up(repoPath string, dbPassword string, testnet bool) error {
+	var dbPath string
+	if testnet {
+		dbPath = path.Join(repoPath, "datastore", "testnet.db")
+	} else {
+		dbPath = path.Join(repoPath, "datastore", "mainnet.db")
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return err
+	}
+	if dbPassword != "" {
+		p := "pragma key='" + dbPassword + "';"
+		if _, err := db.Exec(p); err != nil {
+			return err
+		}
+	}
+
+	// add column for encrypted metadata to blocks
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare("alter table blocks add column dataMetadataCipher blob;")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	_, err = stmt.Exec()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	tx.Commit()
+
+	// update version
+	f1, err := os.Create(path.Join(repoPath, "repover"))
+	if err != nil {
+		return err
+	}
+	defer f1.Close()
+	if _, err = f1.Write([]byte("2")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (Migration001) Down(repoPath string, dbPassword string, testnet bool) error {
+	return nil
+}

--- a/repo/model.go
+++ b/repo/model.go
@@ -35,6 +35,7 @@ type Block struct {
 	DataKeyCipher      []byte `json:"data_key_cipher"`
 	DataCaptionCipher  []byte `json:"data_caption_cipher"`
 	DataUsernameCipher []byte `json:"data_username_cipher"`
+	DataMetadataCipher []byte `json:"data_metadata_cipher"`
 }
 
 type DataBlockConfig struct {
@@ -42,6 +43,7 @@ type DataBlockConfig struct {
 	DataKeyCipher      []byte `json:"data_key_cipher"`
 	DataCaptionCipher  []byte `json:"data_caption_cipher"`
 	DataUsernameCipher []byte `json:"data_username_cipher"`
+	DataMetadataCipher []byte `json:"data_metadata_cipher"`
 }
 
 type BlockType int

--- a/textile.go
+++ b/textile.go
@@ -263,7 +263,7 @@ func main() {
 			})
 			cafeCmd.AddCmd(&ishell.Cmd{
 				Name: "register",
-				Help: "show connected peers (same as `ipfs swarm peers`)",
+				Help: "cafe register",
 				Func: cmd.CafeRegister,
 			})
 			cafeCmd.AddCmd(&ishell.Cmd{
@@ -362,8 +362,8 @@ func main() {
 			})
 			photoCmd.AddCmd(&ishell.Cmd{
 				Name: "meta",
-				Help: "cat photo metadata",
-				Func: cmd.CatPhotoMetadata,
+				Help: "get photo metadata",
+				Func: cmd.GetPhotoMetadata,
 			})
 			photoCmd.AddCmd(&ishell.Cmd{
 				Name: "ls",

--- a/wallet/thread/helpers.go
+++ b/wallet/thread/helpers.go
@@ -2,7 +2,6 @@ package thread
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/pkg/errors"
 	"github.com/textileio/textile-go/crypto"
 	"github.com/textileio/textile-go/repo"
@@ -51,16 +50,19 @@ func (t *Thread) GetBlockData(path string, block *repo.Block) ([]byte, error) {
 	return crypto.DecryptAES(cipher, key)
 }
 
-// GetPhotoMetaData returns photo metadata under an id
+// GetPhotoMetaData returns photo metadata indexed under a block
 func (t *Thread) GetPhotoMetaData(id string, block *repo.Block) (*util.PhotoMetadata, error) {
-	file, err := t.GetBlockData(fmt.Sprintf("%s/meta", id), block)
+	key, err := t.GetBlockDataKey(block)
 	if err != nil {
 		return nil, err
 	}
-	var data *util.PhotoMetadata
-	err = json.Unmarshal(file, &data)
+	metadatab, err := crypto.DecryptAES(block.DataMetadataCipher, key)
 	if err != nil {
 		return nil, err
 	}
-	return data, nil
+	var metadata *util.PhotoMetadata
+	if err := json.Unmarshal(metadatab, &metadata); err != nil {
+		return nil, err
+	}
+	return metadata, nil
 }

--- a/wallet/thread/thread.go
+++ b/wallet/thread/thread.go
@@ -395,6 +395,7 @@ func (t *Thread) indexBlock(id string, header *pb.ThreadBlockHeader, blockType r
 		DataKeyCipher:      dataConf.DataKeyCipher,
 		DataCaptionCipher:  dataConf.DataCaptionCipher,
 		DataUsernameCipher: dataConf.DataUsernameCipher,
+		DataMetadataCipher: dataConf.DataMetadataCipher,
 	}
 	if err := t.blocks().Add(index); err != nil {
 		return err


### PR DESCRIPTION
Did this one way (by adding the aspect ratio directly to the pb messages), then realized a much cleaner method: Index _all_ the metadata as a blob _on the way in_ by cating `/meta` when a photo is added to a thread and when it's received from another peer. This way, we can keep the same structure but only ever cat the data once per node.

fixes #233 