### PR TITLE
getImageDataForMinWidth API

### DIFF
--- a/mobile/photos.go
+++ b/mobile/photos.go
@@ -164,12 +164,19 @@ func (m *Mobile) GetPhotoData(id string, path string) (string, error) {
 		log.Errorf("get block data failed %s: %s", id, err)
 		return "", err
 	}
-	_, formatStr, err := image.DecodeConfig(bytes.NewReader(data))
+	var format string
+	meta, err := thrd.GetPhotoMetaData(id, block)
 	if err != nil {
-		log.Errorf("could not determine image format: %s", err)
-		return "", err
+		log.Warningf("get indexed photo meta data failed, decoding...")
+		_, format, err = image.DecodeConfig(bytes.NewReader(data))
+		if err != nil {
+			log.Errorf("could not determine image format: %s", err)
+			return "", err
+		}
+	} else {
+		format = meta.EncodingFormat
 	}
-	prefix := getImageDataURLPrefix(util.Format(formatStr))
+	prefix := getImageDataURLPrefix(util.Format(format))
 	encoded := libp2pc.ConfigEncodeKey(data)
 	img := &ImageData{Url: prefix + encoded}
 	return toJSON(img)

--- a/mobile/photos.go
+++ b/mobile/photos.go
@@ -146,7 +146,7 @@ func (m *Mobile) GetPhotos(offsetId string, limit int, threadId string) (string,
 	return toJSON(photos)
 }
 
-// GetPhotoData returns a data url for an image under a path
+// GetPhotoData returns a data url of an image under a path
 func (m *Mobile) GetPhotoData(id string, path string) (string, error) {
 	block, err := core.Node.Wallet.GetBlockByDataId(id)
 	if err != nil {
@@ -173,6 +173,12 @@ func (m *Mobile) GetPhotoData(id string, path string) (string, error) {
 	encoded := libp2pc.ConfigEncodeKey(data)
 	img := &ImageData{Url: prefix + encoded}
 	return toJSON(img)
+}
+
+// GetPhotoDataForSize returns a data url of an image at or above requested size, or the next best option
+func (m *Mobile) GetPhotoDataForMinWidth(id string, minWidth int) (string, error) {
+	path := util.ImagePathForSize(util.ImageSizeForMinWidth(minWidth))
+	return m.GetPhotoData(id, string(path))
 }
 
 // GetPhotoMetadata returns a meta data object for a photo

--- a/util/photos.go
+++ b/util/photos.go
@@ -36,6 +36,40 @@ const (
 	LargeSize               = 1600
 )
 
+func ImageSizeForMinWidth(width int) ImageSize {
+	if width <= 100 {
+		return ThumbnailSize
+	} else if width <= 320 {
+		return SmallSize
+	} else if width <= 800 {
+		return MediumSize
+	} else {
+		return LargeSize
+	}
+}
+
+type ImagePath string
+
+const (
+	ThumbnailPath ImagePath = "/thumb"
+	SmallPath               = "/small"
+	MediumPath              = "/medium"
+	LargePath               = "/photo"
+)
+
+func ImagePathForSize(size ImageSize) ImagePath {
+	switch size {
+	case ThumbnailSize:
+		return ThumbnailPath
+	case SmallSize:
+		return SmallPath
+	case MediumSize:
+		return MediumPath
+	default:
+		return LargePath
+	}
+}
+
 type Metadata struct {
 	Version string    `json:"version"`
 	Created time.Time `json:"created,omitempty"`

--- a/wallet/thread/helpers.go
+++ b/wallet/thread/helpers.go
@@ -56,6 +56,9 @@ func (t *Thread) GetPhotoMetaData(id string, block *repo.Block) (*util.PhotoMeta
 	if err != nil {
 		return nil, err
 	}
+	if block.DataMetadataCipher == nil {
+		return nil, errors.New("metadata was not indexed")
+	}
 	metadatab, err := crypto.DecryptAES(block.DataMetadataCipher, key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Getting image data was also improved by the switch to index meta data on the block... no longer need to decode the image data to determine the correct the data url prefix - can use the indexed encoding format.

fixes #232 