### PR TITLE
Unpin on ignore, expose to Mobile

### DIFF
--- a/cmd/photos.go
+++ b/cmd/photos.go
@@ -238,9 +238,14 @@ func IgnorePhoto(c *ishell.Context) {
 	}
 	id := c.Args[0]
 
-	block, thrd, err := getBlockAndThreadForDataId(id)
+	block, err := core.Node.Wallet.GetBlock(id)
 	if err != nil {
 		c.Err(err)
+		return
+	}
+	_, thrd := core.Node.Wallet.GetThread(block.ThreadId)
+	if thrd == nil {
+		c.Err(errors.New(fmt.Sprintf("could not find thread %s", block.ThreadId)))
 		return
 	}
 

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -26,8 +26,9 @@ var repo = "testdata/.textile"
 
 var mobile *Mobile
 var defaultThreadId string
-var threadId string
+var threadId, threadId2 string
 var addedPhotoId string
+var sharedBlockId string
 var addedPhotoKey string
 var deviceId string
 
@@ -283,9 +284,31 @@ func TestMobile_SharePhotoToThread(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if _, err := mobile.SharePhotoToThread(addedPhotoId, item.Id, "howdy"); err != nil {
+	threadId2 = item.Id
+	sharedBlockId, err = mobile.SharePhotoToThread(addedPhotoId, item.Id, "howdy")
+	if err != nil {
 		t.Errorf("share photo to thread failed: %s", err)
 		return
+	}
+}
+
+func TestMobile_IgnorePhoto(t *testing.T) {
+	if _, err := mobile.IgnorePhoto(sharedBlockId); err != nil {
+		t.Errorf("ignore photo failed: %s", err)
+		return
+	}
+	res, err := mobile.GetPhotos("", -1, threadId2)
+	if err != nil {
+		t.Errorf("get photos failed: %s", err)
+		return
+	}
+	photos := Photos{}
+	if err := json.Unmarshal([]byte(res), &photos); err != nil {
+		t.Error(err)
+		return
+	}
+	if len(photos.Items) != 0 {
+		t.Errorf("ignore photo bad result")
 	}
 }
 

--- a/util/ipfs.go
+++ b/util/ipfs.go
@@ -249,6 +249,27 @@ func PinPath(ipfs *core.IpfsNode, path string, recursive bool) error {
 	return nil
 }
 
+// UnpinPath takes an ipfs path string and unpins it
+func UnpinPath(ipfs *core.IpfsNode, path string) error {
+	ip, err := coreapi.ParsePath(path)
+	if err != nil {
+		log.Errorf("error unpinning path: %s: %s", path, err)
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ipfs.Context(), pinTimeout)
+	defer cancel()
+	api := coreapi.NewCoreAPI(ipfs)
+	if err := api.Pin().Rm(ctx, ip); err != nil {
+		return err
+	}
+	defer func() {
+		if recover() != nil {
+			log.Debug("node stopped")
+		}
+	}()
+	return nil
+}
+
 // PinDirectory pins a directory exluding any provided links
 func PinDirectory(ipfs *core.IpfsNode, dir ipld.Node, exclude []string) error {
 	ctx, cancel := context.WithTimeout(ipfs.Context(), pinTimeout)

--- a/wallet/thread/ignores.go
+++ b/wallet/thread/ignores.go
@@ -6,20 +6,21 @@ import (
 	"github.com/segmentio/ksuid"
 	"github.com/textileio/textile-go/pb"
 	"github.com/textileio/textile-go/repo"
+	"github.com/textileio/textile-go/util"
 	"gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
 	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 	libp2pc "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
+	"strings"
 	"time"
 )
 
-// Ignore adds an outgoing ignore block, dataId is the target block to ignore
-func (t *Thread) Ignore(dataId string) (mh.Multihash, error) {
+// Ignore adds an outgoing ignore block targeted at another block to ignore
+func (t *Thread) Ignore(blockId string) (mh.Multihash, error) {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
-	// dataId is a fellow block id,
 	// adding an ignore specific prefix here to ensure future flexibility
-	dataId = fmt.Sprintf("ignore-%s", dataId)
+	dataId := fmt.Sprintf("ignore-%s", blockId)
 
 	// build block
 	header, err := t.newBlockHeader(time.Now())
@@ -40,10 +41,18 @@ func (t *Thread) Ignore(dataId string) (mh.Multihash, error) {
 
 	// index it locally
 	dconf := &repo.DataBlockConfig{
-		DataId: dataId,
+		DataId: content.DataId,
 	}
 	if err := t.indexBlock(id, header, repo.IgnoreBlock, dconf); err != nil {
 		return nil, err
+	}
+
+	// unpin dataId if present
+	block := t.blocks().Get(blockId)
+	if block != nil && block.DataId != "" {
+		if err := util.UnpinPath(t.ipfs(), block.DataId); err != nil {
+			return nil, err
+		}
 	}
 
 	// update head
@@ -115,6 +124,15 @@ func (t *Thread) HandleIgnoreBlock(from *peer.ID, env *pb.Envelope, signed *pb.S
 	}
 	if err := t.indexBlock(id, content.Header, repo.IgnoreBlock, dconf); err != nil {
 		return nil, err
+	}
+
+	// unpin dataId if present
+	blockId := strings.Replace(content.DataId, "ignore-", "", 1)
+	block := t.blocks().Get(blockId)
+	if block != nil && block.DataId != "" {
+		if err := util.UnpinPath(t.ipfs(), block.DataId); err != nil {
+			log.Warningf("failed to unpin data %s for block %s: %s", block.DataId, block.Id, err)
+		}
 	}
 
 	// back prop


### PR DESCRIPTION
When a block is ignored by adding an "ignore" block, the data the ignored block points to (if present) will be unpinned from the local node.

Remote unpinning is a little trickier... will kick that can down the road.

Mobile changes:
- `IgnorePhoto(blockId string) (string, error)` method, note that it needs `blockId`, not the photo's id because a photo may be in multiple threads
- `Photo` now has a `block_id` field, which would be needed if user wanted to ignore that photo

fixes #171 