### PR TITLE
refactor(notifications): add username and category

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -127,9 +127,16 @@ func start(a *astilectron.Astilectron, w []*astilectron.Window, _ *astilectron.M
 				if !ok {
 					return
 				}
+				var username string
+				if notification.ActorUsername != "" {
+					username = notification.ActorUsername
+				} else {
+					username = notification.ActorId
+				}
 				var note = a.NewNotification(&astilectron.NotificationOptions{
-					Body: notification.Body,
-					Icon: "/resources/icon.png",
+					Title: notification.Category,
+					Body:  fmt.Sprintf("%s %s.", username, notification.Body),
+					Icon:  "/resources/icon.png",
 				})
 				if err := note.Create(); err != nil {
 					astilog.Error(err)

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -161,7 +161,7 @@ func initDatabaseTables(db *sql.DB, password string) error {
     create table blocks (id text primary key not null, date integer not null, parents text not null, threadId text not null, authorPk text not null, type integer not null, dataId text, dataKeyCipher blob, dataCaptionCipher blob, dataUsernameCipher blob, dataMetadataCipher blob);
     create index block_dataId on blocks (dataId);
     create index block_threadId_type_date on blocks (threadId, type, date);
-    create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null);
+    create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null, actorUn text not null, category text not null);
     create index notification_targetId on notifications (targetId);
     create index notification_actorId on notifications (actorId);
     create index notification_read on notifications (read);

--- a/repo/db/notifications_test.go
+++ b/repo/db/notifications_test.go
@@ -23,11 +23,13 @@ func setupNotificationDB() {
 
 func TestNotificationDB_Add(t *testing.T) {
 	err := notifdb.Add(&repo.Notification{
-		Id:       "abcde",
-		Date:     time.Now(),
-		ActorId:  ksuid.New().String(),
-		TargetId: ksuid.New().String(),
-		Type:     repo.ReceivedInviteNotification,
+		Id:            "abcde",
+		Date:          time.Now(),
+		ActorId:       ksuid.New().String(),
+		TargetId:      ksuid.New().String(),
+		Type:          repo.ReceivedInviteNotification,
+		ActorUsername: "tester",
+		Category:      "test",
 	})
 	if err != nil {
 		t.Error(err)
@@ -66,21 +68,25 @@ func TestNotificationDB_Read(t *testing.T) {
 func TestNotificationDB_ReadAll(t *testing.T) {
 	setupNotificationDB()
 	err := notifdb.Add(&repo.Notification{
-		Id:       "abcde",
-		Date:     time.Now(),
-		ActorId:  ksuid.New().String(),
-		TargetId: ksuid.New().String(),
-		Type:     repo.ReceivedInviteNotification,
+		Id:            "abcde",
+		Date:          time.Now(),
+		ActorId:       ksuid.New().String(),
+		TargetId:      ksuid.New().String(),
+		Type:          repo.ReceivedInviteNotification,
+		ActorUsername: "tester",
+		Category:      "test",
 	})
 	if err != nil {
 		t.Error(err)
 	}
 	err = notifdb.Add(&repo.Notification{
-		Id:       "abcdef",
-		Date:     time.Now(),
-		ActorId:  ksuid.New().String(),
-		TargetId: ksuid.New().String(),
-		Type:     repo.PeerJoinedNotification,
+		Id:            "abcdef",
+		Date:          time.Now(),
+		ActorId:       ksuid.New().String(),
+		TargetId:      ksuid.New().String(),
+		Type:          repo.PeerJoinedNotification,
+		ActorUsername: "tester",
+		Category:      "test",
 	})
 	if err != nil {
 		t.Error(err)
@@ -99,31 +105,37 @@ func TestNotificationDB_ReadAll(t *testing.T) {
 func TestNotificationDB_List(t *testing.T) {
 	setupNotificationDB()
 	err := notifdb.Add(&repo.Notification{
-		Id:       "abc",
-		Date:     time.Now(),
-		ActorId:  "actor1",
-		TargetId: "target1",
-		Type:     repo.ReceivedInviteNotification,
+		Id:            "abc",
+		Date:          time.Now(),
+		ActorId:       "actor1",
+		TargetId:      "target1",
+		Type:          repo.ReceivedInviteNotification,
+		ActorUsername: "tester",
+		Category:      "test",
 	})
 	if err != nil {
 		t.Error(err)
 	}
 	err = notifdb.Add(&repo.Notification{
-		Id:       "def",
-		Date:     time.Now().Add(time.Minute),
-		ActorId:  "actor1",
-		TargetId: "target2",
-		Type:     repo.PeerJoinedNotification,
+		Id:            "def",
+		Date:          time.Now().Add(time.Minute),
+		ActorId:       "actor1",
+		TargetId:      "target2",
+		Type:          repo.PeerJoinedNotification,
+		ActorUsername: "tester",
+		Category:      "test",
 	})
 	if err != nil {
 		t.Error(err)
 	}
 	err = notifdb.Add(&repo.Notification{
-		Id:       "ghi",
-		Date:     time.Now().Add(time.Minute * 2),
-		ActorId:  "actor2",
-		TargetId: "target2",
-		Type:     repo.CommentAddedNotification,
+		Id:            "ghi",
+		Date:          time.Now().Add(time.Minute * 2),
+		ActorId:       "actor2",
+		TargetId:      "target2",
+		Type:          repo.CommentAddedNotification,
+		ActorUsername: "tester",
+		Category:      "test",
 	})
 	if err != nil {
 		t.Error(err)

--- a/repo/init.go
+++ b/repo/init.go
@@ -20,7 +20,7 @@ var log = logging.MustGetLogger("repo")
 
 var ErrRepoExists = errors.New("repo not empty, reinitializing would overwrite your keys")
 
-const repover = "3"
+const repover = "4"
 
 func DoInit(repoRoot string, version string, mnemonic *string, initDB func(string) error, initConfig func(time.Time) error) (string, error) {
 	if err := checkWriteable(repoRoot); err != nil {

--- a/repo/migrations.go
+++ b/repo/migrations.go
@@ -17,6 +17,7 @@ var migrations = []Migration{
 	migs.Migration000{},
 	migs.Migration001{},
 	migs.Migration002{},
+	migs.Migration003{},
 }
 
 // migrateUp looks at the currently active migration version and will migrate all the way up (applying all up migrations)

--- a/repo/migrations/migration003.go
+++ b/repo/migrations/migration003.go
@@ -1,0 +1,71 @@
+package migrations
+
+import (
+	"database/sql"
+	_ "github.com/mutecomm/go-sqlcipher"
+	"os"
+	"path"
+)
+
+type Migration003 struct{}
+
+func (Migration003) Up(repoPath string, dbPassword string, testnet bool) error {
+	var dbPath string
+	if testnet {
+		dbPath = path.Join(repoPath, "datastore", "testnet.db")
+	} else {
+		dbPath = path.Join(repoPath, "datastore", "mainnet.db")
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return err
+	}
+	if dbPassword != "" {
+		p := "pragma key='" + dbPassword + "';"
+		if _, err := db.Exec(p); err != nil {
+			return err
+		}
+	}
+
+	// add column for username and category to notifications
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt1, err := tx.Prepare("alter table notifications add column actorUn text not null default '';")
+	if err != nil {
+		return err
+	}
+	defer stmt1.Close()
+	_, err = stmt1.Exec()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	stmt2, err := tx.Prepare("alter table notifications add column category text not null default '';")
+	if err != nil {
+		return err
+	}
+	defer stmt2.Close()
+	_, err = stmt2.Exec()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	tx.Commit()
+
+	// update version
+	f4, err := os.Create(path.Join(repoPath, "repover"))
+	if err != nil {
+		return err
+	}
+	defer f4.Close()
+	if _, err = f4.Write([]byte("4")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (Migration003) Down(repoPath string, dbPassword string, testnet bool) error {
+	return nil
+}

--- a/repo/migrations/migration003_test.go
+++ b/repo/migrations/migration003_test.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func initAt002(db *sql.DB, password string) error {
+	var sqlStmt string
+	if password != "" {
+		sqlStmt = "PRAGMA key = '" + password + "';"
+	}
+	sqlStmt += `
+    create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null);
+    create index notification_targetId on notifications (targetId);
+    create index notification_actorId on notifications (actorId);
+    create index notification_read on notifications (read);
+	`
+	_, err := db.Exec(sqlStmt)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("insert into notifications(id, date, actorId, targetId, type, read, body) values(?,?,?,?,?,?,?)", "test", 0, "actorId", "targetId", 0, 0, "hey!")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestMigration003(t *testing.T) {
+	var dbPath string
+	os.Mkdir("./datastore", os.ModePerm)
+	dbPath = path.Join("./", "datastore", "mainnet.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if err := initAt002(db, ""); err != nil {
+		t.Error(err)
+		return
+	}
+
+	// go up
+	var m Migration003
+	err = m.Up("./", "", false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// test new fields
+	_, err = db.Exec("update notifications set actorUn=? where id=?", "james", "test")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = db.Exec("update notifications set category=? where id=?", "bikes", "test")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// ensure that version file was updated
+	version, err := ioutil.ReadFile("./repover")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if string(version) != "4" {
+		t.Error("failed to write new repo version")
+		return
+	}
+
+	if err := m.Down("./", "", false); err != nil {
+		t.Error(err)
+		return
+	}
+	os.RemoveAll("./datastore")
+	os.RemoveAll("./repover")
+}

--- a/repo/model.go
+++ b/repo/model.go
@@ -82,13 +82,15 @@ func (b BlockType) Description() string {
 }
 
 type Notification struct {
-	Id       string           `json:"id"`
-	Date     time.Time        `json:"date"`
-	ActorId  string           `json:"actor_id"`  // peer id
-	TargetId string           `json:"target_id"` // inviteId | deviceId | blockId
-	Type     NotificationType `json:"type"`
-	Read     bool             `json:"read"`
-	Body     string           `json:"body"`
+	Id            string           `json:"id"`
+	Date          time.Time        `json:"date"`
+	ActorId       string           `json:"actor_id"`       // peer id
+	ActorUsername string           `json:"actor_username"` // peer username
+	TargetId      string           `json:"target_id"`      // inviteId | deviceId | blockId
+	Type          NotificationType `json:"type"`
+	Read          bool             `json:"read"`
+	Body          string           `json:"body"`
+	Category      string           `json:"category"`
 }
 
 type NotificationType int
@@ -102,6 +104,27 @@ const (
 	PeerJoinedNotification                             // peerA joined (blockId)
 	PeerLeftNotification                               // peerA left (blockId)
 )
+
+func (n NotificationType) Description() string {
+	switch n {
+	case ReceivedInviteNotification:
+		return "RECEIVED_INVITE"
+	case DeviceAddedNotification:
+		return "DEVICE_ADDED"
+	case PhotoAddedNotification:
+		return "PHOTO_ADDED"
+	case CommentAddedNotification:
+		return "COMMENT_ADDED"
+	case LikeAddedNotification:
+		return "LIKE_ADDED"
+	case PeerJoinedNotification:
+		return "PEER_JOINED"
+	case PeerLeftNotification:
+		return "PEER_LEFT"
+	default:
+		return "INVALID"
+	}
+}
 
 type PinRequest struct {
 	Id   string    `json:"id"`

--- a/textile.go
+++ b/textile.go
@@ -537,7 +537,14 @@ func start() error {
 				if !ok {
 					return
 				}
-				fmt.Println(yellow(fmt.Sprintf("%s (%s)", notification.Body, notification.Id)))
+				var username string
+				if notification.ActorUsername != "" {
+					username = notification.ActorUsername
+				} else {
+					username = notification.ActorId
+				}
+				note := fmt.Sprintf("%s %s (%s)", username, notification.Body, notification.Id)
+				fmt.Println(yellow(note))
 			}
 		}
 	}()

--- a/wallet/devices.go
+++ b/wallet/devices.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"errors"
-	"fmt"
 	"github.com/segmentio/ksuid"
 	"github.com/textileio/textile-go/repo"
 	libp2pc "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
@@ -50,12 +49,14 @@ func (w *Wallet) AddDevice(name string, pk libp2pc.PubKey) error {
 		return err
 	}
 	notification := &repo.Notification{
-		Id:       ksuid.New().String(),
-		Date:     time.Now(),
-		ActorId:  id,
-		TargetId: deviceModel.Id,
-		Type:     repo.DeviceAddedNotification,
-		Body:     fmt.Sprintf("You are now paired with a new device named %s.", deviceModel.Name),
+		Id:            ksuid.New().String(),
+		Date:          time.Now(),
+		ActorId:       id,
+		ActorUsername: "You",
+		TargetId:      deviceModel.Id,
+		Type:          repo.DeviceAddedNotification,
+		Body:          "paired with a new device",
+		Category:      deviceModel.Name,
 	}
 	return w.sendNotification(notification)
 }


### PR DESCRIPTION
Adds `actor_username` and `category` to notifications. So, the username is no longer automatically part of `body`. E.g., on desktop, the notification is shown like this:

```
var username string
if notification.ActorUsername != "" {
    username = notification.ActorUsername
} else {
    username = notification.ActorId
}
var note = a.NewNotification(&astilectron.NotificationOptions{
    Title: notification.Category,
    Body:  fmt.Sprintf("%s %s.", username, notification.Body),
    Icon:  "/resources/icon.png",
})
```
- `actor_username` could be "", so check for that, fallback to `actor_id`
- `category` should be used since it has relevant info like that thread name
- left up to client to add a period ^