### PR TITLE
Mishmash

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -6,6 +6,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 # install dependencies
 RUN apt-get update \
     && apt-get install -y curl \
+    && apt-get install -y mingw-w64 \
     && apt-get -y autoclean
 
 # install dep

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -5,7 +5,6 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # install dependencies
 RUN apt-get update \
-    && apt-get install -y gcc \
     && apt-get install -y curl \
     && apt-get install -y mingw-w64 \
     && apt-get -y autoclean

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -5,6 +5,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # install dependencies
 RUN apt-get update \
+    && apt-get install -y gcc \
     && apt-get install -y curl \
     && apt-get install -y mingw-w64 \
     && apt-get -y autoclean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
         name: cross-compile
         command: |
           gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64" -output="{{.OS}}-{{.Arch}}"
-          CC="x86_64-w64-mingw32-gcc" CXX="x86_64-w64-mingw32-g++" gox -cgo -osarch="windows/386 windows/amd64" -output="{{.OS}}-{{.Arch}}"
+          CC="x86_64-w64-mingw32-gcc" CXX="x86_64-w64-mingw32-g++" gox -cgo -osarch="windows/amd64" -output="{{.OS}}-{{.Arch}}"
     - run:
         name: collect artifacts
         command: |
@@ -115,7 +115,7 @@ jobs:
           cp dist/README.md tmp/
           cp dist/install.sh tmp/
           cd tmp
-          declare -a arr=("linux-amd64" "linux-386" "linux-arm" "darwin-amd64" "windows-386.exe" "windows-amd64.exe")
+          declare -a arr=("linux-amd64" "linux-386" "linux-arm" "darwin-amd64" "windows-amd64.exe")
           for i in "${arr[@]}"
           do
               OSARCH=${i%.*}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
     - run:
         name: cross-compile
         command: |
-          gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64 windows/386 windows/amd64" -output="{{.OS}}-{{.Arch}}"
-          gox -cgo -osarch="windows/386 windows/amd64" -output="{{.OS}}-{{.Arch}}"
+          gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64" -output="{{.OS}}-{{.Arch}}"
+          CC="x86_64-w64-mingw32-gcc" CXX="x86_64-w64-mingw32-g++" gox -cgo -osarch="windows/386 windows/amd64" -output="{{.OS}}-{{.Arch}}"
     - run:
         name: collect artifacts
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
         name: cross-compile
         command: |
           gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64 windows/386 windows/amd64" -output="{{.OS}}-{{.Arch}}"
+          gox -cgo -osarch="windows/386 windows/amd64" -output="{{.OS}}-{{.Arch}}"
     - run:
         name: collect artifacts
         command: |
@@ -342,32 +343,24 @@ workflows:
         requires:
         - unit-test
         filters:
-          branches:
-            only: master
           tags:
             only: /.*/
     - build-desktop:
         requires:
         - unit-test
         filters:
-          branches:
-            only: master
           tags:
             only: /.*/
     - build-ios-framework:
         requires:
         - unit-test
         filters:
-          branches:
-            only: master
           tags:
             only: /.*/
     - build-android-framework:
         requires:
         - unit-test
         filters:
-          branches:
-            only: master
           tags:
             only: /.*/
     - release:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 build:
-	gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64 windows/386 windows/amd64" -output="textile-go-{{.OS}}-{{.Arch}}"
+	gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64" -output="textile-go-{{.OS}}-{{.Arch}}"
+	CC="x86_64-w64-mingw32-gcc" CXX="x86_64-w64-mingw32-g++" gox -cgo -osarch="windows/386 windows/amd64" -output="textile-go-{{.OS}}-{{.Arch}}"
 	mv textile-go-* dist
 
 build_desktop:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This will start the interactive commit prompt.
 
 ## Building
 
+These instructions assume the build OS is either Darwin or Linux. As such, `mingw-w64` is needed for Windows cross-compiled builds. `brew install mingw-w64` for Darwin, `apt-get install mingw-w64` for Debian, etc.
+
 There are various things to build:
 
 #### The CLI:
@@ -81,7 +83,7 @@ The build is made by a vendored version of `go-astilectron-bundler`. Due to Go's
 ```
 go install ./vendor/github.com/asticode/go-astilectron-bundler/astilectron-bundler
 ```
-Run `make` to build the app for Darwin:
+Run `make` to build the app for Darwin, Linux, and Windows:
 ```
 make build_desktop
 ```
@@ -89,7 +91,7 @@ Double-click the built app in `desktop/output/darwin-amd64`, or run it directly:
 ```
 cd desktop && go run *.go
 ```
-To build for Linux or Windows, see [go-astilectron-bundler](https://github.com/asticode/go-astilectron-bundler).
+See [go-astilectron-bundler](https://github.com/asticode/go-astilectron-bundler) for more build configurations.
 
 ## Contributing
 

--- a/desktop/bundler.json
+++ b/desktop/bundler.json
@@ -3,7 +3,15 @@
   "environments": [
     {"arch": "amd64", "os": "linux"},
     {"arch": "amd64", "os": "darwin"},
-    {"arch": "amd64", "os": "windows"}
+    {
+      "arch": "amd64",
+      "os": "windows",
+      "env": {
+        "CC": "x86_64-w64-mingw32-gcc",
+        "CXX": "x86_64-w64-mingw32-g++",
+        "CGO_ENABLED": "1"
+      }
+    }
   ],
   "icon_path_darwin": "resources/icon.icns",
   "icon_path_linux": "resources/icon.png",

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/textileio/textile-go/wallet/thread"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 )
 
@@ -58,7 +59,12 @@ func start(a *astilectron.Astilectron, w []*astilectron.Window, _ *astilectron.M
 	}
 
 	// ensure app support folder is created
-	appDir := filepath.Join(home, "Library/Application Support/Textile")
+	var appDir string
+	if runtime.GOOS == "darwin" {
+		appDir = filepath.Join(home, "Library/Application Support/Textile")
+	} else {
+		appDir = filepath.Join(home, ".textile")
+	}
 	if err := os.MkdirAll(appDir, 0755); err != nil {
 		return err
 	}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -150,6 +150,14 @@ func start(a *astilectron.Astilectron, w []*astilectron.Window, _ *astilectron.M
 				}
 				if err := note.Show(); err != nil {
 					astilog.Error(err)
+					return
+				}
+
+				// tmp auto-accept thread invites
+				if notification.Type == repo.ReceivedInviteNotification {
+					if _, err := core.Node.Wallet.AcceptThreadInvite(notification.TargetId); err != nil {
+						astilog.Error(err)
+					}
 				}
 			}
 		}

--- a/desktop/resources/app/static/js/textile.js
+++ b/desktop/resources/app/static/js/textile.js
@@ -113,6 +113,19 @@ function addThread(update) {
   }
 }
 
+function removeThread(update) {
+  let ul = $('.threads')
+  let active = $('.thread.active').attr('id') === update.id
+  $('#' + id).remove()
+  if (active) {
+    if (ul.children().length > 0) {
+      loadFirstThread()
+    } else {
+
+    }
+  }
+}
+
 function loadFirstThread() {
   setTimeout(function () {
     $('.threads li').first().click()

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -111,7 +111,7 @@ func (s *TextileService) handleThreadInvite(pid peer.ID, pmes *pb.Envelope, opti
 		return nil, err
 	}
 	notification.Body = "invited you to join"
-	notification.Category = invite.SuggestedName
+	notification.Category = "#" + invite.SuggestedName
 	if err := s.notify(notification); err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (s *TextileService) handleThreadJoin(pid peer.ID, pmes *pb.Envelope, option
 		return nil, err
 	}
 	notification.Body = "joined"
-	notification.Category = thrd.Name
+	notification.Category = "#" + thrd.Name
 	if err := s.notify(notification); err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (s *TextileService) handleThreadLeave(pid peer.ID, pmes *pb.Envelope, optio
 		return nil, err
 	}
 	notification.Body = "left"
-	notification.Category = thrd.Name
+	notification.Category = "#" + thrd.Name
 	if err := s.notify(notification); err != nil {
 		return nil, err
 	}
@@ -238,6 +238,10 @@ func (s *TextileService) handleThreadData(pid peer.ID, pmes *pb.Envelope, option
 	id := addr.B58String()
 
 	// send notification
+	// check for old username format
+	if data.Header.AuthorUnCipher == nil {
+		data.Header.AuthorUnCipher = data.UsernameCipher
+	}
 	notification, err := buildNotification(thrd.PrivKey, data.Header, id, repo.PhotoAddedNotification)
 	if err != nil {
 		return nil, err
@@ -248,7 +252,7 @@ func (s *TextileService) handleThreadData(pid peer.ID, pmes *pb.Envelope, option
 	case pb.ThreadData_TEXT:
 		break
 	}
-	notification.Category = thrd.Name
+	notification.Category = "#" + thrd.Name
 	if err := s.notify(notification); err != nil {
 		return nil, err
 	}

--- a/textile.go
+++ b/textile.go
@@ -28,7 +28,7 @@ type Opts struct {
 	Version bool `short:"v" long:"version" description:"print the version number and exit"`
 
 	// repo location
-	DataDir string `short:"r" long:"data-dir" description:"specify the data directory to be used"`
+	RepoPath string `short:"r" long:"repo-dir" description:"specify a custom repository path"`
 
 	// logging options
 	LogLevel   string `short:"l" long:"log-level" description:"set the logging level [debug, info, notice, warning, error, critical]" default:"debug"`
@@ -77,9 +77,9 @@ func main() {
 		return
 	}
 
-	// handle data dir
-	dataDir := Options.DataDir
-	if len(Options.DataDir) == 0 {
+	// handle repo path
+	repoPath := Options.RepoPath
+	if len(Options.RepoPath) == 0 {
 		// get homedir
 		home, err := homedir.Dir()
 		if err != nil {
@@ -93,7 +93,7 @@ func main() {
 			fmt.Println(fmt.Errorf("create repo directory failed: %s", err.Error()))
 			return
 		}
-		dataDir = filepath.Join(appDir, "repo")
+		repoPath = filepath.Join(appDir, "repo")
 	}
 
 	// determine log level
@@ -106,7 +106,7 @@ func main() {
 	// node setup
 	config := core.NodeConfig{
 		WalletConfig: wallet.Config{
-			RepoPath:   dataDir,
+			RepoPath:   repoPath,
 			SwarmPorts: Options.SwarmPorts,
 			IsMobile:   false,
 			IsServer:   Options.ServerMode,

--- a/wallet/thread/photos.go
+++ b/wallet/thread/photos.go
@@ -178,6 +178,11 @@ func (t *Thread) HandleDataBlock(from *peer.ID, env *pb.Envelope, signed *pb.Sig
 		}
 		dconf.DataMetadataCipher = metadataCipher
 
+		// check for old username format
+		if content.Header.AuthorUnCipher == nil {
+			content.Header.AuthorUnCipher = content.UsernameCipher
+		}
+
 		// index
 		if err := t.indexBlock(id, content.Header, repo.PhotoBlock, dconf); err != nil {
 			return nil, err

--- a/wallet/thread/thread.go
+++ b/wallet/thread/thread.go
@@ -82,7 +82,7 @@ func NewThread(model *repo.Thread, config *Config) (*Thread, error) {
 		Id:            model.Id,
 		Name:          model.Name,
 		PrivKey:       sk,
-		updates:       make(chan Update),
+		updates:       make(chan Update, 10),
 		repoPath:      config.RepoPath,
 		ipfs:          config.Ipfs,
 		blocks:        config.Blocks,

--- a/wallet/threads.go
+++ b/wallet/threads.go
@@ -103,6 +103,8 @@ func (w *Wallet) RemoveThread(id string) (mh.Multihash, error) {
 		return nil, err
 	}
 
+	// TODO: tell devices somehow?
+
 	// clean up
 	thrd.Close()
 	copy(w.threads[*i:], w.threads[*i+1:])

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -158,8 +158,8 @@ func (w *Wallet) Start() error {
 	}()
 	log.Info("starting wallet...")
 	w.online = make(chan struct{})
-	w.updates = make(chan Update)
-	w.notifications = make(chan repo.Notification)
+	w.updates = make(chan Update, 10)
+	w.notifications = make(chan repo.Notification, 10)
 
 	// raise file descriptor limit
 	if err := utilmain.ManageFdLimit(); err != nil {
@@ -575,10 +575,7 @@ func (w *Wallet) sendUpdate(update Update) {
 			log.Error("update channel already closed")
 		}
 	}()
-	select {
-	case w.updates <- update:
-	default:
-	}
+	w.updates <- update
 }
 
 // sendNotification adds a notification to the notification channel
@@ -594,10 +591,8 @@ func (w *Wallet) sendNotification(notification *repo.Notification) error {
 			log.Error("notification channel already closed")
 		}
 	}()
-	select {
-	case w.notifications <- *notification:
-	default:
-	}
+	w.notifications <- *notification
+
 	return nil
 }
 


### PR DESCRIPTION
Bunch of little stuff...

- Adds back the auto-accept in-network invites, but to desktop only (handled in the notification listener)
- Fixes Windows desktop build (needed `CGO_ENABLED` and `mingw-w64` installed on the build system
- Same goes for the CLI built for Windows but hasn't been tested
- Updates README with Windows info (building from source requires having the `mingw-w64` cross compiler installed
- Adds back-compatibility for photo usernames (older versions still won't see newer version usernames, but oh well, newer can now see older)
- Fixes Desktop issue where only one thread would show in side-bar during a pair (moved wallet and notification update channels to buffered channels, and enforced blocking on send... basically, messages were getting dropped because the receiver wasn't able to process them fast enough)
- Building binaries for every commit now, nice to see those fail / succeed before entering master (but only the tests are required for a merge to happen)
- Fixed Desktop issue where repo was being placed in a darwin-ish path (`~/Library/Application Support/Textile` on linux and windows

fixes #201 