### PR TITLE
Delete notifications with related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Until [Textile Photos](https://www.textile.photos) is ready for public release, 
 ## Install
 
 ```
-go get github.com/textileio/textile-go
+$ go get github.com/textileio/textile-go
 ```
 
 You'll need a few different tools here to get setup...
@@ -23,7 +23,7 @@ You'll need a few different tools here to get setup...
 Golang package manager:
 
 ```
-brew install dep
+$ brew install dep
 ```
 
 #### Install `gx`
@@ -31,8 +31,8 @@ brew install dep
 IPFS package manager:
 
 ```
-go get -u github.com/whyrusleeping/gx
-go get -u github.com/whyrusleeping/gx-go
+$ go get -u github.com/whyrusleeping/gx
+$ go get -u github.com/whyrusleeping/gx-go
 ```
 
 #### Install `node`
@@ -40,7 +40,7 @@ go get -u github.com/whyrusleeping/gx-go
 NodeJS is used for git hooks and some build tooling:
 
 ```
-brew install node
+$ brew install node
 ```
 
 #### Install dependencies
@@ -48,7 +48,7 @@ brew install node
 Finally, download deps managed by `gx` and `dep`:
 
 ```
-npm run setup
+$ npm run setup
 ```
 
 This will start the interactive commit prompt.
@@ -62,34 +62,39 @@ There are various things to build:
 #### The CLI:
 
 ```
-make build
+$ go get github.com/mitchellh/gox
+$ make build
 ```
 
 #### The iOS Framework:
 
 ```
-make ios_framework
+$ go get golang.org/x/mobile/cmd/gomobile
+$ gomobile init
+$ make ios_framework
 ```
 
 #### The Android Framework:
 
 ```
-make android_framework
+$ go get golang.org/x/mobile/cmd/gomobile
+$ gomobile init
+$ make android_framework
 ```
 
 #### The Desktop Application
 
 The build is made by a vendored version of `go-astilectron-bundler`. Due to Go's painful package management, you'll want to delete any `go-astilectron`-related binaries and source code you have installed from `github.com/asticode` in your `$GOPATH`. Then you can install the vendored `go-astilectron-bundler`:
 ```
-go install ./vendor/github.com/asticode/go-astilectron-bundler/astilectron-bundler
+$ go install ./vendor/github.com/asticode/go-astilectron-bundler/astilectron-bundler
 ```
 Run `make` to build the app for Darwin, Linux, and Windows:
 ```
-make build_desktop
+$ make build_desktop
 ```
 Double-click the built app in `desktop/output/darwin-amd64`, or run it directly:
 ```
-cd desktop && go run *.go
+$ cd desktop && go run *.go
 ```
 See [go-astilectron-bundler](https://github.com/asticode/go-astilectron-bundler) for more build configurations.
 
@@ -98,7 +103,7 @@ See [go-astilectron-bundler](https://github.com/asticode/go-astilectron-bundler)
 The easiest way to write a valid commit message is to use the `npm` script:
 
 ```
-npm run cm
+$ npm run cm
 ```
 
 ## Acknowledgments

--- a/cmd/notifications.go
+++ b/cmd/notifications.go
@@ -23,7 +23,13 @@ func ListNotifications(c *ishell.Context) {
 		if !notif.Read {
 			body += " (unread)"
 		}
-		c.Println(yellow(fmt.Sprintf("%s: %s", notif.Id, body)))
+		var username string
+		if notif.ActorUsername != "" {
+			username = notif.ActorUsername
+		} else {
+			username = notif.ActorId
+		}
+		c.Println(yellow(fmt.Sprintf("%s: #%s: %s %s.", notif.Id, notif.Category, username, body)))
 	}
 }
 

--- a/cmd/notifications.go
+++ b/cmd/notifications.go
@@ -29,7 +29,7 @@ func ListNotifications(c *ishell.Context) {
 		} else {
 			username = notif.ActorId
 		}
-		c.Println(yellow(fmt.Sprintf("%s: #%s: %s %s.", notif.Id, notif.Category, username, body)))
+		c.Println(yellow(fmt.Sprintf("%s: #%s: %s %s.", notif.Id, notif.Subject, username, body)))
 	}
 }
 

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -43,6 +43,11 @@ func AddThread(c *ishell.Context) {
 		return
 	}
 
+	if err := core.Node.Wallet.InviteDevices(thrd); err != nil {
+		c.Err(err)
+		return
+	}
+
 	cyan := color.New(color.FgCyan).SprintFunc()
 	c.Println(cyan(fmt.Sprintf("added thread %s with name %s", thrd.Id, name)))
 }

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -37,7 +37,7 @@ func AddThread(c *ishell.Context) {
 		return
 	}
 
-	thrd, err := core.Node.Wallet.AddThread(name, sk)
+	thrd, err := core.Node.Wallet.AddThread(name, sk, true)
 	if err != nil {
 		c.Err(err)
 		return

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -147,7 +147,7 @@ func start(a *astilectron.Astilectron, w []*astilectron.Window, _ *astilectron.M
 					username = notification.ActorId
 				}
 				var note = a.NewNotification(&astilectron.NotificationOptions{
-					Title: "#" + notification.Category,
+					Title: "#" + notification.Subject,
 					Body:  fmt.Sprintf("%s %s.", username, notification.Body),
 					Icon:  "/resources/icon.png",
 				})
@@ -158,7 +158,7 @@ func start(a *astilectron.Astilectron, w []*astilectron.Window, _ *astilectron.M
 						if _, err := core.Node.Wallet.AcceptThreadInvite(tid); err != nil {
 							astilog.Error(err)
 						}
-					}(notification.TargetId)
+					}(notification.BlockId)
 				}
 
 				// show notification

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -512,7 +512,7 @@ func TestMobile_GetNotifications(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if len(notes.Items) != 2 {
+	if len(notes.Items) != 1 {
 		t.Error("get notifications bad result")
 		return
 	}
@@ -520,7 +520,7 @@ func TestMobile_GetNotifications(t *testing.T) {
 }
 
 func TestMobile_CountUnreadNotifications(t *testing.T) {
-	if mobile.CountUnreadNotifications() != 2 {
+	if mobile.CountUnreadNotifications() != 1 {
 		t.Error("count unread notifications bad result")
 	}
 }
@@ -529,7 +529,7 @@ func TestMobile_ReadNotification(t *testing.T) {
 	if err := mobile.ReadNotification(noteId); err != nil {
 		t.Error(err)
 	}
-	if mobile.CountUnreadNotifications() != 1 {
+	if mobile.CountUnreadNotifications() != 0 {
 		t.Error("read notification bad result")
 	}
 }

--- a/mobile/notifications.go
+++ b/mobile/notifications.go
@@ -37,9 +37,9 @@ func (m *Mobile) ReadAllNotifications() error {
 
 // AcceptThreadInviteViaNotification call core AcceptThreadInviteViaNotification
 func (m *Mobile) AcceptThreadInviteViaNotification(id string) (string, error) {
-	thrdId, err := core.Node.Wallet.AcceptThreadInviteViaNotification(id)
+	addr, err := core.Node.Wallet.AcceptThreadInviteViaNotification(id)
 	if err != nil {
 		return "", err
 	}
-	return *thrdId, nil
+	return addr.B58String(), nil
 }

--- a/mobile/threads.go
+++ b/mobile/threads.go
@@ -48,6 +48,11 @@ func (m *Mobile) AddThread(name string, mnemonic string) (string, error) {
 		return "", err
 	}
 
+	// invite devices
+	if err := core.Node.Wallet.InviteDevices(thrd); err != nil {
+		return "", err
+	}
+
 	// build json
 	peers := thrd.Peers()
 	item := Thread{

--- a/mobile/threads.go
+++ b/mobile/threads.go
@@ -120,11 +120,11 @@ func (m *Mobile) AddExternalThreadInvite(threadId string) (string, error) {
 // AcceptExternalThreadInvite notifies the thread of a join
 func (m *Mobile) AcceptExternalThreadInvite(id string, key string) (string, error) {
 	m.waitForOnline()
-	thrdId, err := core.Node.Wallet.AcceptExternalThreadInvite(id, []byte(key))
+	addr, err := core.Node.Wallet.AcceptExternalThreadInvite(id, []byte(key))
 	if err != nil {
 		return "", err
 	}
-	return *thrdId, nil
+	return addr.B58String(), nil
 }
 
 // RemoveThread call core RemoveDevice

--- a/mobile/threads.go
+++ b/mobile/threads.go
@@ -43,7 +43,7 @@ func (m *Mobile) AddThread(name string, mnemonic string) (string, error) {
 	if mnemonic != "" {
 		mnem = &mnemonic
 	}
-	thrd, _, err := core.Node.Wallet.AddThreadWithMnemonic(name, mnem)
+	thrd, _, err := core.Node.Wallet.AddThreadWithMnemonic(name, mnem, true)
 	if err != nil {
 		return "", err
 	}

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -109,9 +109,9 @@ func (s *TextileService) handleThreadInvite(pid peer.ID, pmes *pb.Envelope, opti
 	if err != nil {
 		return nil, err
 	}
-	notification.TargetId = id // invite block
-	notification.Category = invite.SuggestedName
-	notification.CategoryId = libp2pc.ConfigEncodeKey(invite.Header.ThreadPk)
+	notification.Subject = invite.SuggestedName
+	notification.SubjectId = libp2pc.ConfigEncodeKey(invite.Header.ThreadPk)
+	notification.BlockId = id // invite block
 	notification.Body = "invited you to join"
 	if err := s.notify(notification); err != nil {
 		return nil, err
@@ -154,10 +154,10 @@ func (s *TextileService) handleThreadJoin(pid peer.ID, pmes *pb.Envelope, option
 	if err != nil {
 		return nil, err
 	}
+	notification.Subject = thrd.Name
+	notification.SubjectId = thrd.Id
+	notification.BlockId = addr.B58String()
 	notification.Body = "joined"
-	notification.TargetId = addr.B58String()
-	notification.Category = thrd.Name
-	notification.CategoryId = thrd.Id
 	if err := s.notify(notification); err != nil {
 		return nil, err
 	}
@@ -199,10 +199,10 @@ func (s *TextileService) handleThreadLeave(pid peer.ID, pmes *pb.Envelope, optio
 	if err != nil {
 		return nil, err
 	}
+	notification.Subject = thrd.Name
+	notification.SubjectId = thrd.Id
+	notification.BlockId = addr.B58String()
 	notification.Body = "left"
-	notification.TargetId = addr.B58String()
-	notification.Category = thrd.Name
-	notification.CategoryId = thrd.Id
 	if err := s.notify(notification); err != nil {
 		return nil, err
 	}
@@ -251,6 +251,7 @@ func (s *TextileService) handleThreadData(pid peer.ID, pmes *pb.Envelope, option
 		if err != nil {
 			return nil, err
 		}
+		notification.DataId = data.DataId
 		notification.Body = "added a photo"
 	case pb.ThreadData_TEXT:
 		notification, err = buildNotification(thrd.PrivKey, data.Header, repo.TextAddedNotification)
@@ -263,9 +264,9 @@ func (s *TextileService) handleThreadData(pid peer.ID, pmes *pb.Envelope, option
 		}
 		notification.Body = string(body)
 	}
-	notification.TargetId = addr.B58String()
-	notification.Category = thrd.Name
-	notification.CategoryId = thrd.Id
+	notification.BlockId = addr.B58String()
+	notification.Subject = thrd.Name
+	notification.SubjectId = thrd.Id
 	if err := s.notify(notification); err != nil {
 		return nil, err
 	}
@@ -300,8 +301,6 @@ func (s *TextileService) handleThreadIgnore(pid peer.ID, pmes *pb.Envelope, opti
 	if _, err := thrd.HandleIgnoreBlock(&pid, pmes, signed, ignore, false); err != nil {
 		return nil, err
 	}
-
-	// TODO: remove notifications w/ this targetId
 
 	return nil, nil
 }
@@ -488,8 +487,6 @@ func (s *TextileService) handleError(peer peer.ID, pmes *pb.Envelope, options in
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO
 
 	return nil, nil
 }

--- a/net/service/service.go
+++ b/net/service/service.go
@@ -35,7 +35,6 @@ type TextileService struct {
 	datastore repo.Datastore
 	node      *core.IpfsNode
 	getThread func(string) (*int, *thread.Thread)
-	addThread func(string, libp2pc.PrivKey) (*thread.Thread, error)
 	notify    func(notificaiton *repo.Notification) error
 	sender    map[peer.ID]*sender
 	senderlk  sync.Mutex
@@ -45,7 +44,6 @@ func NewService(
 	node *core.IpfsNode,
 	datastore repo.Datastore,
 	getThread func(string) (*int, *thread.Thread),
-	addThread func(string, libp2pc.PrivKey) (*thread.Thread, error),
 	notify func(notificaiton *repo.Notification) error,
 ) *TextileService {
 	service := &TextileService{
@@ -56,7 +54,6 @@ func NewService(
 		datastore: datastore,
 		node:      node,
 		getThread: getThread,
-		addThread: addThread,
 		notify:    notify,
 		sender:    make(map[peer.ID]*sender),
 	}

--- a/repo/datastore.go
+++ b/repo/datastore.go
@@ -96,6 +96,7 @@ type NotificationStore interface {
 	Delete(id string) error
 	DeleteByActorId(actorId string) error
 	DeleteByTargetId(targetId string) error
+	DeleteByCategoryId(categoryId string) error
 }
 
 type OfflineMessageStore interface {

--- a/repo/datastore.go
+++ b/repo/datastore.go
@@ -95,8 +95,8 @@ type NotificationStore interface {
 	CountUnread() int
 	Delete(id string) error
 	DeleteByActorId(actorId string) error
-	DeleteByTargetId(targetId string) error
-	DeleteByCategoryId(categoryId string) error
+	DeleteBySubjectId(subjectId string) error
+	DeleteByBlockId(blockId string) error
 }
 
 type OfflineMessageStore interface {

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -161,8 +161,9 @@ func initDatabaseTables(db *sql.DB, password string) error {
     create table blocks (id text primary key not null, date integer not null, parents text not null, threadId text not null, authorPk text not null, type integer not null, dataId text, dataKeyCipher blob, dataCaptionCipher blob, dataUsernameCipher blob, dataMetadataCipher blob);
     create index block_dataId on blocks (dataId);
     create index block_threadId_type_date on blocks (threadId, type, date);
-    create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null, actorUn text not null, category text not null);
+    create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null, actorUn text not null, category text not null, categoryId text not null);
     create index notification_targetId on notifications (targetId);
+    create index notification_categoryId on notifications (categoryId);
     create index notification_actorId on notifications (actorId);
     create index notification_read on notifications (read);
     create table offlinemessages (url text primary key not null, date integer, message blob);

--- a/repo/db/db.go
+++ b/repo/db/db.go
@@ -161,10 +161,10 @@ func initDatabaseTables(db *sql.DB, password string) error {
     create table blocks (id text primary key not null, date integer not null, parents text not null, threadId text not null, authorPk text not null, type integer not null, dataId text, dataKeyCipher blob, dataCaptionCipher blob, dataUsernameCipher blob, dataMetadataCipher blob);
     create index block_dataId on blocks (dataId);
     create index block_threadId_type_date on blocks (threadId, type, date);
-    create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null, actorUn text not null, category text not null, categoryId text not null);
-    create index notification_targetId on notifications (targetId);
-    create index notification_categoryId on notifications (categoryId);
-    create index notification_actorId on notifications (actorId);
+    create table notifications (id text primary key not null, date integer not null, actorId text not null, actorUsername text not null, subject text not null, subjectId text not null, blockId text, dataId text, type integer not null, body text not null, read integer not null);
+    create index notification_actorId on notifications (actorId);    
+    create index notification_subjectId on notifications (subjectId);
+    create index notification_blockId on notifications (blockId);
     create index notification_read on notifications (read);
     create table offlinemessages (url text primary key not null, date integer, message blob);
 	create table pointers (id text primary key not null, key text, address text, cancelId text, purpose integer, date integer);

--- a/repo/db/notifications.go
+++ b/repo/db/notifications.go
@@ -23,7 +23,7 @@ func (c *NotificationDB) Add(notification *repo.Notification) error {
 	if err != nil {
 		return err
 	}
-	stm := `insert into notifications(id, date, actorId, targetId, type, read, body, actorUn, category, categoryId) values(?,?,?,?,?,?,?,?,?,?)`
+	stm := `insert into notifications(id, date, actorId, actorUsername, subject, subjectId, blockId, dataId, type, body, read) values(?,?,?,?,?,?,?,?,?,?,?)`
 	stmt, err := tx.Prepare(stm)
 	if err != nil {
 		log.Errorf("error in tx prepare: %s", err)
@@ -34,13 +34,14 @@ func (c *NotificationDB) Add(notification *repo.Notification) error {
 		notification.Id,
 		int(notification.Date.Unix()),
 		notification.ActorId,
-		notification.TargetId,
-		int(notification.Type),
-		false,
-		notification.Body,
 		notification.ActorUsername,
-		notification.Category,
-		notification.CategoryId,
+		notification.Subject,
+		notification.SubjectId,
+		notification.BlockId,
+		notification.DataId,
+		int(notification.Type),
+		notification.Body,
+		false,
 	)
 	if err != nil {
 		tx.Rollback()
@@ -115,17 +116,17 @@ func (c *NotificationDB) DeleteByActorId(actorId string) error {
 	return err
 }
 
-func (c *NotificationDB) DeleteByTargetId(targetId string) error {
+func (c *NotificationDB) DeleteBySubjectId(subjectId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	_, err := c.db.Exec("delete from notifications where targetId=?", targetId)
+	_, err := c.db.Exec("delete from notifications where subjectId=?", subjectId)
 	return err
 }
 
-func (c *NotificationDB) DeleteByCategoryId(categoryId string) error {
+func (c *NotificationDB) DeleteByBlockId(blockId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	_, err := c.db.Exec("delete from notifications where categoryId=?", categoryId)
+	_, err := c.db.Exec("delete from notifications where blockId=?", blockId)
 	return err
 }
 
@@ -137,9 +138,9 @@ func (c *NotificationDB) handleQuery(stm string) []repo.Notification {
 		return nil
 	}
 	for rows.Next() {
-		var id, actorId, targetId, body, actorUn, category, categoryId string
+		var id, actorId, actorUsername, subject, subjectId, blockId, dataId, body string
 		var dateInt, typeInt, readInt int
-		if err := rows.Scan(&id, &dateInt, &actorId, &targetId, &typeInt, &readInt, &body, &actorUn, &category, &categoryId); err != nil {
+		if err := rows.Scan(&id, &dateInt, &actorId, &actorUsername, &subject, &subjectId, &blockId, &dataId, &typeInt, &body, &readInt); err != nil {
 			log.Errorf("error in db scan: %s", err)
 			continue
 		}
@@ -151,10 +152,11 @@ func (c *NotificationDB) handleQuery(stm string) []repo.Notification {
 			Id:            id,
 			Date:          time.Unix(int64(dateInt), 0),
 			ActorId:       actorId,
-			ActorUsername: actorUn,
-			TargetId:      targetId,
-			Category:      category,
-			CategoryId:    categoryId,
+			ActorUsername: actorUsername,
+			Subject:       subject,
+			SubjectId:     subjectId,
+			BlockId:       blockId,
+			DataId:        dataId,
 			Type:          repo.NotificationType(typeInt),
 			Body:          body,
 			Read:          read,

--- a/repo/db/notifications_test.go
+++ b/repo/db/notifications_test.go
@@ -30,6 +30,7 @@ func TestNotificationDB_Add(t *testing.T) {
 		Type:          repo.ReceivedInviteNotification,
 		ActorUsername: "tester",
 		Category:      "test",
+		CategoryId:    ksuid.New().String(),
 	})
 	if err != nil {
 		t.Error(err)
@@ -75,6 +76,7 @@ func TestNotificationDB_ReadAll(t *testing.T) {
 		Type:          repo.ReceivedInviteNotification,
 		ActorUsername: "tester",
 		Category:      "test",
+		CategoryId:    ksuid.New().String(),
 	})
 	if err != nil {
 		t.Error(err)
@@ -87,6 +89,7 @@ func TestNotificationDB_ReadAll(t *testing.T) {
 		Type:          repo.PeerJoinedNotification,
 		ActorUsername: "tester",
 		Category:      "test",
+		CategoryId:    ksuid.New().String(),
 	})
 	if err != nil {
 		t.Error(err)
@@ -112,6 +115,7 @@ func TestNotificationDB_List(t *testing.T) {
 		Type:          repo.ReceivedInviteNotification,
 		ActorUsername: "tester",
 		Category:      "test",
+		CategoryId:    ksuid.New().String(),
 	})
 	if err != nil {
 		t.Error(err)
@@ -124,6 +128,7 @@ func TestNotificationDB_List(t *testing.T) {
 		Type:          repo.PeerJoinedNotification,
 		ActorUsername: "tester",
 		Category:      "test",
+		CategoryId:    ksuid.New().String(),
 	})
 	if err != nil {
 		t.Error(err)
@@ -136,12 +141,26 @@ func TestNotificationDB_List(t *testing.T) {
 		Type:          repo.CommentAddedNotification,
 		ActorUsername: "tester",
 		Category:      "test",
+		CategoryId:    ksuid.New().String(),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	err = notifdb.Add(&repo.Notification{
+		Id:            "jkl",
+		Date:          time.Now().Add(time.Minute * 3),
+		ActorId:       "actor3",
+		TargetId:      "target3",
+		Type:          repo.CommentAddedNotification,
+		ActorUsername: "tester",
+		Category:      "test",
+		CategoryId:    "category1",
 	})
 	if err != nil {
 		t.Error(err)
 	}
 	all := notifdb.List("", -1, "")
-	if len(all) != 3 {
+	if len(all) != 4 {
 		t.Error("returned incorrect number of notifications")
 		return
 	}
@@ -151,7 +170,7 @@ func TestNotificationDB_List(t *testing.T) {
 		return
 	}
 	offset := notifdb.List(limited[0].Id, -1, "")
-	if len(offset) != 2 {
+	if len(offset) != 3 {
 		t.Error("returned incorrect number of notifications")
 		return
 	}
@@ -163,7 +182,7 @@ func TestNotificationDB_List(t *testing.T) {
 
 func TestNotificationDB_CountUnread(t *testing.T) {
 	cnt := notifdb.CountUnread()
-	if cnt != 3 {
+	if cnt != 4 {
 		t.Error("returned incorrect count of unread notifications")
 	}
 }
@@ -205,6 +224,20 @@ func TestNotificationDB_DeleteByTargetId(t *testing.T) {
 	defer stmt.Close()
 	var id string
 	err = stmt.QueryRow("ghi").Scan(&id)
+	if err == nil {
+		t.Error("delete failed")
+	}
+}
+
+func TestNotificationDB_DeleteByCategoryId(t *testing.T) {
+	err := notifdb.DeleteByCategoryId("category1")
+	if err != nil {
+		t.Error(err)
+	}
+	stmt, err := notifdb.PrepareQuery("select id from notifications where id=?")
+	defer stmt.Close()
+	var id string
+	err = stmt.QueryRow("jkl").Scan(&id)
 	if err == nil {
 		t.Error("delete failed")
 	}

--- a/repo/db/notifications_test.go
+++ b/repo/db/notifications_test.go
@@ -26,11 +26,11 @@ func TestNotificationDB_Add(t *testing.T) {
 		Id:            "abcde",
 		Date:          time.Now(),
 		ActorId:       ksuid.New().String(),
-		TargetId:      ksuid.New().String(),
-		Type:          repo.ReceivedInviteNotification,
 		ActorUsername: "tester",
-		Category:      "test",
-		CategoryId:    ksuid.New().String(),
+		Subject:       "test",
+		SubjectId:     ksuid.New().String(),
+		BlockId:       ksuid.New().String(),
+		Type:          repo.ReceivedInviteNotification,
 	})
 	if err != nil {
 		t.Error(err)
@@ -72,11 +72,11 @@ func TestNotificationDB_ReadAll(t *testing.T) {
 		Id:            "abcde",
 		Date:          time.Now(),
 		ActorId:       ksuid.New().String(),
-		TargetId:      ksuid.New().String(),
-		Type:          repo.ReceivedInviteNotification,
 		ActorUsername: "tester",
-		Category:      "test",
-		CategoryId:    ksuid.New().String(),
+		Subject:       "test",
+		SubjectId:     ksuid.New().String(),
+		BlockId:       ksuid.New().String(),
+		Type:          repo.ReceivedInviteNotification,
 	})
 	if err != nil {
 		t.Error(err)
@@ -85,11 +85,11 @@ func TestNotificationDB_ReadAll(t *testing.T) {
 		Id:            "abcdef",
 		Date:          time.Now(),
 		ActorId:       ksuid.New().String(),
-		TargetId:      ksuid.New().String(),
-		Type:          repo.PeerJoinedNotification,
 		ActorUsername: "tester",
-		Category:      "test",
-		CategoryId:    ksuid.New().String(),
+		Subject:       "test",
+		SubjectId:     ksuid.New().String(),
+		BlockId:       ksuid.New().String(),
+		Type:          repo.PeerJoinedNotification,
 	})
 	if err != nil {
 		t.Error(err)
@@ -111,11 +111,11 @@ func TestNotificationDB_List(t *testing.T) {
 		Id:            "abc",
 		Date:          time.Now(),
 		ActorId:       "actor1",
-		TargetId:      "target1",
-		Type:          repo.ReceivedInviteNotification,
 		ActorUsername: "tester",
-		Category:      "test",
-		CategoryId:    ksuid.New().String(),
+		Subject:       "test",
+		SubjectId:     ksuid.New().String(),
+		BlockId:       "block1",
+		Type:          repo.ReceivedInviteNotification,
 	})
 	if err != nil {
 		t.Error(err)
@@ -124,11 +124,11 @@ func TestNotificationDB_List(t *testing.T) {
 		Id:            "def",
 		Date:          time.Now().Add(time.Minute),
 		ActorId:       "actor1",
-		TargetId:      "target2",
-		Type:          repo.PeerJoinedNotification,
 		ActorUsername: "tester",
-		Category:      "test",
-		CategoryId:    ksuid.New().String(),
+		Subject:       "test",
+		SubjectId:     ksuid.New().String(),
+		BlockId:       "block2",
+		Type:          repo.PeerJoinedNotification,
 	})
 	if err != nil {
 		t.Error(err)
@@ -137,11 +137,11 @@ func TestNotificationDB_List(t *testing.T) {
 		Id:            "ghi",
 		Date:          time.Now().Add(time.Minute * 2),
 		ActorId:       "actor2",
-		TargetId:      "target2",
-		Type:          repo.CommentAddedNotification,
 		ActorUsername: "tester",
-		Category:      "test",
-		CategoryId:    ksuid.New().String(),
+		Subject:       "test",
+		SubjectId:     ksuid.New().String(),
+		BlockId:       "block2",
+		Type:          repo.CommentAddedNotification,
 	})
 	if err != nil {
 		t.Error(err)
@@ -150,11 +150,12 @@ func TestNotificationDB_List(t *testing.T) {
 		Id:            "jkl",
 		Date:          time.Now().Add(time.Minute * 3),
 		ActorId:       "actor3",
-		TargetId:      "target3",
-		Type:          repo.CommentAddedNotification,
 		ActorUsername: "tester",
-		Category:      "test",
-		CategoryId:    "category1",
+		Subject:       "test",
+		SubjectId:     "subject1",
+		BlockId:       "block3",
+		DataId:        "data",
+		Type:          repo.PhotoAddedNotification,
 	})
 	if err != nil {
 		t.Error(err)
@@ -174,7 +175,7 @@ func TestNotificationDB_List(t *testing.T) {
 		t.Error("returned incorrect number of notifications")
 		return
 	}
-	filtered := notifdb.List("", -1, "targetId='target1'")
+	filtered := notifdb.List("", -1, "blockId='block1'")
 	if len(filtered) != 1 {
 		t.Error("returned incorrect number of notifications")
 	}
@@ -215,8 +216,8 @@ func TestNotificationDB_DeleteByActorId(t *testing.T) {
 	}
 }
 
-func TestNotificationDB_DeleteByTargetId(t *testing.T) {
-	err := notifdb.DeleteByTargetId("target2")
+func TestNotificationDB_DeleteByBlockId(t *testing.T) {
+	err := notifdb.DeleteByBlockId("block2")
 	if err != nil {
 		t.Error(err)
 	}
@@ -229,8 +230,8 @@ func TestNotificationDB_DeleteByTargetId(t *testing.T) {
 	}
 }
 
-func TestNotificationDB_DeleteByCategoryId(t *testing.T) {
-	err := notifdb.DeleteByCategoryId("category1")
+func TestNotificationDB_DeleteBySubjectId(t *testing.T) {
+	err := notifdb.DeleteBySubjectId("subject1")
 	if err != nil {
 		t.Error(err)
 	}

--- a/repo/init.go
+++ b/repo/init.go
@@ -20,7 +20,7 @@ var log = logging.MustGetLogger("repo")
 
 var ErrRepoExists = errors.New("repo not empty, reinitializing would overwrite your keys")
 
-const repover = "4"
+const repover = "5"
 
 func DoInit(repoRoot string, version string, mnemonic *string, initDB func(string) error, initConfig func(time.Time) error) (string, error) {
 	if err := checkWriteable(repoRoot); err != nil {

--- a/repo/migrations.go
+++ b/repo/migrations.go
@@ -18,6 +18,7 @@ var migrations = []Migration{
 	migs.Migration001{},
 	migs.Migration002{},
 	migs.Migration003{},
+	migs.Migration004{},
 }
 
 // migrateUp looks at the currently active migration version and will migrate all the way up (applying all up migrations)

--- a/repo/migrations/migration002.go
+++ b/repo/migrations/migration002.go
@@ -28,16 +28,16 @@ func (Migration002) Up(repoPath string, dbPassword string, testnet bool) error {
 	}
 
 	// add notifications table and indexes
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
 	query := `
     create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null);
     create index notification_targetId on notifications (targetId);
     create index notification_actorId on notifications (actorId);
     create index notification_read on notifications (read);
     `
-	tx, err := db.Begin()
-	if err != nil {
-		return err
-	}
 	stmt, err := tx.Prepare(query)
 	if err != nil {
 		return err

--- a/repo/migrations/migration004.go
+++ b/repo/migrations/migration004.go
@@ -1,0 +1,73 @@
+package migrations
+
+import (
+	"database/sql"
+	_ "github.com/mutecomm/go-sqlcipher"
+	"os"
+	"path"
+)
+
+type Migration004 struct{}
+
+func (Migration004) Up(repoPath string, dbPassword string, testnet bool) error {
+	var dbPath string
+	if testnet {
+		dbPath = path.Join(repoPath, "datastore", "testnet.db")
+	} else {
+		dbPath = path.Join(repoPath, "datastore", "mainnet.db")
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return err
+	}
+	if dbPassword != "" {
+		p := "pragma key='" + dbPassword + "';"
+		if _, err := db.Exec(p); err != nil {
+			return err
+		}
+	}
+
+	// add column categoryId to notifications
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt1, err := tx.Prepare("alter table notifications add column categoryId text not null default '';")
+	if err != nil {
+		return err
+	}
+	defer stmt1.Close()
+	_, err = stmt1.Exec()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// add index on categoryId
+	stmt2, err := tx.Prepare("create index notification_categoryId on notifications (categoryId);")
+	if err != nil {
+		return err
+	}
+	defer stmt2.Close()
+	_, err = stmt2.Exec()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	tx.Commit()
+
+	// update version
+	f5, err := os.Create(path.Join(repoPath, "repover"))
+	if err != nil {
+		return err
+	}
+	defer f5.Close()
+	if _, err = f5.Write([]byte("5")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (Migration004) Down(repoPath string, dbPassword string, testnet bool) error {
+	return nil
+}

--- a/repo/migrations/migration004.go
+++ b/repo/migrations/migration004.go
@@ -27,12 +27,12 @@ func (Migration004) Up(repoPath string, dbPassword string, testnet bool) error {
 		}
 	}
 
-	// add column categoryId to notifications
+	// delete notifications table
 	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
-	stmt1, err := tx.Prepare("alter table notifications add column categoryId text not null default '';")
+	stmt1, err := tx.Prepare("drop table notifications;")
 	if err != nil {
 		return err
 	}
@@ -43,8 +43,15 @@ func (Migration004) Up(repoPath string, dbPassword string, testnet bool) error {
 		return err
 	}
 
-	// add index on categoryId
-	stmt2, err := tx.Prepare("create index notification_categoryId on notifications (categoryId);")
+	// re-add notifications table and indexes
+	query := `
+    create table notifications (id text primary key not null, date integer not null, actorId text not null, actorUsername text not null, subject text not null, subjectId text not null, blockId text, dataId text, type integer not null, body text not null, read integer not null);
+    create index notification_actorId on notifications (actorId);    
+    create index notification_subjectId on notifications (subjectId);
+    create index notification_blockId on notifications (blockId);
+    create index notification_read on notifications (read);
+    `
+	stmt2, err := tx.Prepare(query)
 	if err != nil {
 		return err
 	}

--- a/repo/migrations/migration004_test.go
+++ b/repo/migrations/migration004_test.go
@@ -1,0 +1,79 @@
+package migrations
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func initAt003(db *sql.DB, password string) error {
+	var sqlStmt string
+	if password != "" {
+		sqlStmt = "PRAGMA key = '" + password + "';"
+	}
+	sqlStmt += `
+    create table notifications (id text primary key not null, date integer not null, actorId text not null, targetId text not null, type integer not null, read integer not null, body text not null, actorUn text not null, category text not null);
+    create index notification_targetId on notifications (targetId);
+    create index notification_actorId on notifications (actorId);
+    create index notification_read on notifications (read);
+	`
+	_, err := db.Exec(sqlStmt)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("insert into notifications(id, date, actorId, targetId, type, read, body, actorUn, category) values(?,?,?,?,?,?,?,?,?)", "test", 0, "actorId", "targetId", 0, 0, "hey!", "bob", "cats")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestMigration004(t *testing.T) {
+	var dbPath string
+	os.Mkdir("./datastore", os.ModePerm)
+	dbPath = path.Join("./", "datastore", "mainnet.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if err := initAt003(db, ""); err != nil {
+		t.Error(err)
+		return
+	}
+
+	// go up
+	var m Migration004
+	err = m.Up("./", "", false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// test new fields
+	_, err = db.Exec("update notifications set categoryId=? where id=?", "catId", "test")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// ensure that version file was updated
+	version, err := ioutil.ReadFile("./repover")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if string(version) != "5" {
+		t.Error("failed to write new repo version")
+		return
+	}
+
+	if err := m.Down("./", "", false); err != nil {
+		t.Error(err)
+		return
+	}
+	os.RemoveAll("./datastore")
+	os.RemoveAll("./repover")
+}

--- a/repo/migrations/migration004_test.go
+++ b/repo/migrations/migration004_test.go
@@ -52,8 +52,8 @@ func TestMigration004(t *testing.T) {
 		return
 	}
 
-	// test new fields
-	_, err = db.Exec("update notifications set categoryId=? where id=?", "catId", "test")
+	// test new table
+	_, err = db.Exec("insert into notifications(id, date, actorId, actorUsername, subject, subjectId, blockId, dataId, type, body, read) values(?,?,?,?,?,?,?,?,?,?,?)", "test", 0, "actorId", "james", "cats", "catId", "", "", 0, "hey!", 0)
 	if err != nil {
 		t.Error(err)
 		return

--- a/repo/model.go
+++ b/repo/model.go
@@ -84,11 +84,12 @@ func (b BlockType) Description() string {
 type Notification struct {
 	Id            string           `json:"id"`
 	Date          time.Time        `json:"date"`
-	ActorId       string           `json:"actor_id"`       // peer id
-	ActorUsername string           `json:"actor_username"` // peer username
-	TargetId      string           `json:"target_id"`      // blockId | dataId
-	Category      string           `json:"category"`       // threadName | deviceName
-	CategoryId    string           `json:"category_id"`    // threadId | deviceId
+	ActorId       string           `json:"actor_id"`                 // peer id
+	ActorUsername string           `json:"actor_username,omitempty"` // peer username
+	Subject       string           `json:"subject"`                  // thread name | device name
+	SubjectId     string           `json:"subject_id"`               // thread id | device id
+	BlockId       string           `json:"block_id,omitempty"`       // block id
+	DataId        string           `json:"data_id,omitempty"`        // photo id, etc.
 	Type          NotificationType `json:"type"`
 	Body          string           `json:"body"`
 	Read          bool             `json:"read"`
@@ -97,14 +98,14 @@ type Notification struct {
 type NotificationType int
 
 const (
-	ReceivedInviteNotification NotificationType = iota // peerA invited you (inviteId)
-	DeviceAddedNotification                            // new device added (deviceId)
-	PhotoAddedNotification                             // peerA added a photo (blockId)
-	CommentAddedNotification                           // peerA commented on peerB's photo, video, comment, etc. (blockId)
-	LikeAddedNotification                              // peerA liked peerB's photo, video, comment, etc. (blockId)
-	PeerJoinedNotification                             // peerA joined (blockId)
-	PeerLeftNotification                               // peerA left (blockId)
-	TextAddedNotification                              // peerA added a message (blockId)
+	ReceivedInviteNotification NotificationType = iota // peerA invited you
+	DeviceAddedNotification                            // new device added
+	PhotoAddedNotification                             // peerA added a photo
+	CommentAddedNotification                           // peerA commented on peerB's photo, video, comment, etc.
+	LikeAddedNotification                              // peerA liked peerB's photo, video, comment, etc.
+	PeerJoinedNotification                             // peerA joined
+	PeerLeftNotification                               // peerA left
+	TextAddedNotification                              // peerA added a message
 )
 
 func (n NotificationType) Description() string {

--- a/repo/model.go
+++ b/repo/model.go
@@ -86,11 +86,12 @@ type Notification struct {
 	Date          time.Time        `json:"date"`
 	ActorId       string           `json:"actor_id"`       // peer id
 	ActorUsername string           `json:"actor_username"` // peer username
-	TargetId      string           `json:"target_id"`      // inviteId | deviceId | blockId
+	TargetId      string           `json:"target_id"`      // blockId | dataId
+	Category      string           `json:"category"`       // threadName | deviceName
+	CategoryId    string           `json:"category_id"`    // threadId | deviceId
 	Type          NotificationType `json:"type"`
-	Read          bool             `json:"read"`
 	Body          string           `json:"body"`
-	Category      string           `json:"category"`
+	Read          bool             `json:"read"`
 }
 
 type NotificationType int
@@ -103,6 +104,7 @@ const (
 	LikeAddedNotification                              // peerA liked peerB's photo, video, comment, etc. (blockId)
 	PeerJoinedNotification                             // peerA joined (blockId)
 	PeerLeftNotification                               // peerA left (blockId)
+	TextAddedNotification                              // peerA added a message (blockId)
 )
 
 func (n NotificationType) Description() string {

--- a/textile.go
+++ b/textile.go
@@ -548,7 +548,7 @@ func start() error {
 				} else {
 					username = notification.ActorId
 				}
-				note := fmt.Sprintf("#%s: %s %s.", notification.Category, username, notification.Body)
+				note := fmt.Sprintf("#%s: %s %s.", notification.Subject, username, notification.Body)
 				fmt.Println(yellow(note))
 			}
 		}

--- a/wallet/devices.go
+++ b/wallet/devices.go
@@ -53,8 +53,8 @@ func (w *Wallet) AddDevice(name string, pk libp2pc.PubKey) error {
 		Date:          time.Now(),
 		ActorId:       id,
 		ActorUsername: "You",
-		Category:      deviceModel.Name,
-		CategoryId:    deviceModel.Id,
+		Subject:       deviceModel.Name,
+		SubjectId:     deviceModel.Id,
 		Type:          repo.DeviceAddedNotification,
 		Body:          "paired with a new device",
 	}
@@ -77,7 +77,7 @@ func (w *Wallet) RemoveDevice(id string) error {
 	}
 
 	// delete notifications
-	if err := w.datastore.Notifications().DeleteByCategoryId(device.Id); err != nil {
+	if err := w.datastore.Notifications().DeleteBySubjectId(device.Id); err != nil {
 		return err
 	}
 

--- a/wallet/devices.go
+++ b/wallet/devices.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/segmentio/ksuid"
 	"github.com/textileio/textile-go/repo"
+	"github.com/textileio/textile-go/wallet/thread"
 	libp2pc "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
 	"time"
 )
@@ -59,6 +60,24 @@ func (w *Wallet) AddDevice(name string, pk libp2pc.PubKey) error {
 		Body:          "paired with a new device",
 	}
 	return w.sendNotification(notification)
+}
+
+// InviteDevices sends a thread invite to all devices
+func (w *Wallet) InviteDevices(thrd *thread.Thread) error {
+	for _, device := range w.Devices() {
+		dpkb, err := libp2pc.ConfigDecodeKey(device.Id)
+		if err != nil {
+			return err
+		}
+		dpk, err := libp2pc.UnmarshalPublicKey(dpkb)
+		if err != nil {
+			return err
+		}
+		if _, err := thrd.AddInvite(dpk); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RemoveDevice removes a device

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"github.com/textileio/textile-go/repo"
+	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 )
 
 // GetNotifications lists notifications
@@ -27,7 +28,7 @@ func (w *Wallet) ReadAllNotifications() error {
 }
 
 // AcceptThreadInviteViaNotification uses an invite notification to accept an invite to a thread
-func (w *Wallet) AcceptThreadInviteViaNotification(id string) (*string, error) {
+func (w *Wallet) AcceptThreadInviteViaNotification(id string) (mh.Multihash, error) {
 	// look up notification
 	notification := w.datastore.Notifications().Get(id)
 	if notification == nil {
@@ -37,6 +38,6 @@ func (w *Wallet) AcceptThreadInviteViaNotification(id string) (*string, error) {
 		return nil, errors.New(fmt.Sprintf("notification not invite type"))
 	}
 
-	// target id is the invite's block id
-	return w.AcceptThreadInvite(notification.TargetId)
+	// block is the invite's block id
+	return w.AcceptThreadInvite(notification.BlockId)
 }

--- a/wallet/thread/ignores.go
+++ b/wallet/thread/ignores.go
@@ -58,7 +58,7 @@ func (t *Thread) Ignore(blockId string) (mh.Multihash, error) {
 	t.post(env, id, t.Peers())
 
 	// delete notifications
-	if err := t.notifications().DeleteByTargetId(blockId); err != nil {
+	if err := t.notifications().DeleteByBlockId(blockId); err != nil {
 		return nil, err
 	}
 
@@ -119,7 +119,7 @@ func (t *Thread) HandleIgnoreBlock(from *peer.ID, env *pb.Envelope, signed *pb.S
 
 	// delete notifications
 	blockId := strings.Replace(content.DataId, "ignore-", "", 1)
-	if err := t.notifications().DeleteByTargetId(blockId); err != nil {
+	if err := t.notifications().DeleteByBlockId(blockId); err != nil {
 		return nil, err
 	}
 

--- a/wallet/thread/ignores.go
+++ b/wallet/thread/ignores.go
@@ -57,6 +57,11 @@ func (t *Thread) Ignore(blockId string) (mh.Multihash, error) {
 	// post it
 	t.post(env, id, t.Peers())
 
+	// delete notifications
+	if err := t.notifications().DeleteByTargetId(blockId); err != nil {
+		return nil, err
+	}
+
 	log.Debugf("added IGNORE to %s: %s", t.Id, id)
 
 	// all done
@@ -112,6 +117,12 @@ func (t *Thread) HandleIgnoreBlock(from *peer.ID, env *pb.Envelope, signed *pb.S
 		}
 	}
 
+	// delete notifications
+	blockId := strings.Replace(content.DataId, "ignore-", "", 1)
+	if err := t.notifications().DeleteByTargetId(blockId); err != nil {
+		return nil, err
+	}
+
 	// index it locally
 	dconf := &repo.DataBlockConfig{
 		DataId: content.DataId,
@@ -121,7 +132,6 @@ func (t *Thread) HandleIgnoreBlock(from *peer.ID, env *pb.Envelope, signed *pb.S
 	}
 
 	// unpin dataId if present and not part of another thread
-	blockId := strings.Replace(content.DataId, "ignore-", "", 1)
 	t.unpinBlockData(blockId)
 
 	// back prop

--- a/wallet/thread/joins.go
+++ b/wallet/thread/joins.go
@@ -16,12 +16,11 @@ func (t *Thread) Join(inviterPk libp2pc.PubKey, blockId string) (mh.Multihash, e
 	t.mux.Lock()
 	defer t.mux.Unlock()
 
+	// build block
 	inviterPkb, err := inviterPk.Bytes()
 	if err != nil {
 		return nil, err
 	}
-
-	// build block
 	header, err := t.newBlockHeader()
 	if err != nil {
 		return nil, err

--- a/wallet/thread/leaves.go
+++ b/wallet/thread/leaves.go
@@ -47,8 +47,14 @@ func (t *Thread) Leave() (mh.Multihash, error) {
 	if err := t.blocks().DeleteByThreadId(t.Id); err != nil {
 		return nil, err
 	}
+
 	// delete peers
 	if err := t.peers().DeleteByThreadId(t.Id); err != nil {
+		return nil, err
+	}
+
+	// delete notifications
+	if err := t.notifications().DeleteByCategoryId(t.Id); err != nil {
 		return nil, err
 	}
 
@@ -92,6 +98,9 @@ func (t *Thread) HandleLeaveBlock(from *peer.ID, env *pb.Envelope, signed *pb.Si
 		return nil, err
 	}
 	if err := t.peers().Delete(authorId.Pretty(), t.Id); err != nil {
+		return nil, err
+	}
+	if err := t.notifications().DeleteByActorId(t.Id); err != nil {
 		return nil, err
 	}
 

--- a/wallet/thread/leaves.go
+++ b/wallet/thread/leaves.go
@@ -54,7 +54,7 @@ func (t *Thread) Leave() (mh.Multihash, error) {
 	}
 
 	// delete notifications
-	if err := t.notifications().DeleteByCategoryId(t.Id); err != nil {
+	if err := t.notifications().DeleteBySubjectId(t.Id); err != nil {
 		return nil, err
 	}
 

--- a/wallet/thread/thread.go
+++ b/wallet/thread/thread.go
@@ -43,6 +43,7 @@ type Config struct {
 	Ipfs          func() *core.IpfsNode
 	Blocks        func() repo.BlockStore
 	Peers         func() repo.PeerStore
+	Notifications func() repo.NotificationStore
 	GetHead       func() (string, error)
 	UpdateHead    func(head string) error
 	Publish       func(payload []byte) error
@@ -62,6 +63,7 @@ type Thread struct {
 	ipfs          func() *core.IpfsNode
 	blocks        func() repo.BlockStore
 	peers         func() repo.PeerStore
+	notifications func() repo.NotificationStore
 	GetHead       func() (string, error)
 	updateHead    func(head string) error
 	publish       func(payload []byte) error
@@ -87,6 +89,7 @@ func NewThread(model *repo.Thread, config *Config) (*Thread, error) {
 		ipfs:          config.Ipfs,
 		blocks:        config.Blocks,
 		peers:         config.Peers,
+		notifications: config.Notifications,
 		GetHead:       config.GetHead,
 		updateHead:    config.UpdateHead,
 		publish:       config.Publish,

--- a/wallet/thread_test.go
+++ b/wallet/thread_test.go
@@ -33,7 +33,7 @@ func Test_SetupThread(t *testing.T) {
 
 func TestNewThread_WalletOffline(t *testing.T) {
 	var err error
-	thrd, _, err = twallet.AddThreadWithMnemonic("thread1", nil)
+	thrd, _, err = twallet.AddThreadWithMnemonic("thread1", nil, true)
 	if err != nil {
 		t.Errorf("create thread while offline failed: %s", err)
 	}
@@ -42,7 +42,7 @@ func TestNewThread_WalletOffline(t *testing.T) {
 func TestNewThread_WalletOnline(t *testing.T) {
 	<-twallet.Online()
 	var err error
-	_, _, err = twallet.AddThreadWithMnemonic("thread2", nil)
+	_, _, err = twallet.AddThreadWithMnemonic("thread2", nil, true)
 	if err != nil {
 		t.Errorf("create thread while online failed: %s", err)
 	}

--- a/wallet/threads.go
+++ b/wallet/threads.go
@@ -99,11 +99,9 @@ func (w *Wallet) RemoveThread(id string) (mh.Multihash, error) {
 	}
 
 	// remove model from db
-	if err := w.datastore.Threads().Delete(id); err != nil {
+	if err := w.datastore.Threads().Delete(thrd.Id); err != nil {
 		return nil, err
 	}
-
-	// TODO: tell devices somehow?
 
 	// clean up
 	copy(w.threads[*i:], w.threads[*i+1:])
@@ -113,7 +111,7 @@ func (w *Wallet) RemoveThread(id string) (mh.Multihash, error) {
 	// notify listeners
 	w.sendUpdate(Update{Id: thrd.Id, Name: thrd.Name, Type: ThreadRemoved})
 
-	log.Infof("removed thread %s with name %s", id, thrd.Name)
+	log.Infof("removed thread %s with name %s", thrd.Id, thrd.Name)
 
 	return addr, nil
 }

--- a/wallet/threads.go
+++ b/wallet/threads.go
@@ -118,7 +118,7 @@ func (w *Wallet) RemoveThread(id string) (mh.Multihash, error) {
 
 // AcceptThreadInvite attemps to download an encrypted thread key from an internal invite,
 // add the thread, and notify the inviter of the join
-func (w *Wallet) AcceptThreadInvite(blockId string) (*string, error) {
+func (w *Wallet) AcceptThreadInvite(blockId string) (mh.Multihash, error) {
 	if !w.IsOnline() {
 		return nil, ErrOffline
 	}
@@ -188,16 +188,12 @@ func (w *Wallet) AcceptThreadInvite(blockId string) (*string, error) {
 	}
 
 	// join the thread
-	if _, err := thrd.Join(authorPk, blockId); err != nil {
-		return nil, err
-	}
-
-	return &thrd.Id, nil
+	return thrd.Join(authorPk, blockId)
 }
 
 // AcceptExternalThreadInvite attemps to download an encrypted thread key from an external invite,
 // add the thread, and notify the inviter of the join
-func (w *Wallet) AcceptExternalThreadInvite(blockId string, key []byte) (*string, error) {
+func (w *Wallet) AcceptExternalThreadInvite(blockId string, key []byte) (mh.Multihash, error) {
 	if !w.IsOnline() {
 		return nil, ErrOffline
 	}
@@ -258,11 +254,7 @@ func (w *Wallet) AcceptExternalThreadInvite(blockId string, key []byte) (*string
 	}
 
 	// join the thread
-	if _, err := thrd.Join(authorPk, blockId); err != nil {
-		return nil, err
-	}
-
-	return &thrd.Id, nil
+	return thrd.Join(authorPk, blockId)
 }
 
 // Threads lists loaded threads

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -534,8 +534,9 @@ func (w *Wallet) loadThread(mod *repo.Thread) (*thread.Thread, error) {
 		Ipfs: func() *core.IpfsNode {
 			return w.ipfs
 		},
-		Blocks: w.datastore.Blocks,
-		Peers:  w.datastore.Peers,
+		Blocks:        w.datastore.Blocks,
+		Peers:         w.datastore.Peers,
+		Notifications: w.datastore.Notifications,
 		GetHead: func() (string, error) {
 			m := w.datastore.Threads().Get(id)
 			if m == nil {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -55,7 +55,6 @@ const (
 	ThreadRemoved
 	DeviceAdded
 	DeviceRemoved
-	ThreadUpdate
 )
 
 // AddDataResult wraps added data content id and key
@@ -199,7 +198,7 @@ func (w *Wallet) Start() error {
 		})
 
 		// service is now configurable
-		w.service = serv.NewService(w.ipfs, w.datastore, w.GetThread, w.AddThread, w.sendNotification)
+		w.service = serv.NewService(w.ipfs, w.datastore, w.GetThread, w.sendNotification)
 
 		// build the message retriever
 		mrCfg := net.MRConfig{

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -157,7 +157,7 @@ func TestWallet_AddThread(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	thrd, err := wallet.AddThread("test", sk)
+	thrd, err := wallet.AddThread("test", sk, true)
 	if err != nil {
 		t.Errorf("add thread failed: %s", err)
 		return


### PR DESCRIPTION
fixes #253 
fixes #260 

New `Notification` object looks like:
```
type Notification struct {
	Id            string           `json:"id"`
	Date          time.Time        `json:"date"`
	ActorId       string           `json:"actor_id"`                 // peer id
	ActorUsername string           `json:"actor_username,omitempty"` // peer username
	Subject       string           `json:"subject"`                  // thread name | device name
	SubjectId     string           `json:"subject_id"`               // thread id | device id
	BlockId       string           `json:"block_id,omitempty"`       // block id
	DataId        string           `json:"data_id,omitempty"`        // photo id, etc.
	Type          NotificationType `json:"type"`
	Body          string           `json:"body"`
	Read          bool             `json:"read"`
}
```

Refer to comments in ^ for client-side usage. Key points / changes:
- if you want a thread id, it will always be under `subject_id`
- if the notification pertains to a particular photo, it's id will be under `data_id`, which can be used to render a thumbnail
- `block_id` is used internally for deletes in some cases and for in-network invites (the invite id is the block id)
- the result of `AcceptThreadInviteViaNotification` is _no longer the thread id_ because it can be found on the actual notification under `subject_id`... the result is instead the join block's id, to be consistent w/ the rest of the api. 

Also, this fixes an issue with peer discovery that I ran into: If a peer ever needed to recover the thread, they'd have to find the original invite in order to discover the thread creator. So, this we just be sure to join our threads we create as well.
