### PR TITLE
A couple fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,21 +85,54 @@ jobs:
           CAFE_REFERRAL_KEY: woohoo!
 
   build-cli:
-    docker:
-    - image: textile/builder:1.10.3
-    working_directory: /go/src/github.com/textileio/textile-go
+    macos:
+      xcode: "9.4.0"
+    environment:
+      GOPATH: /Users/distiller/go
+    working_directory: ~/go/src/github.com/textileio/textile-go
     steps:
-    - *checkout-linux
-    - *move-linux-src
-    - *restore-linux-dep-cache
-    - *restore-linux-gx-cache
+    - checkout
+    - run:
+        name: install golang
+        command: |
+          brew install golang
+    - run:
+        name: install dep
+        command: brew install dep
+    - run:
+        name: install gx
+        command: |
+          go get -u github.com/whyrusleeping/gx
+          go get -u github.com/whyrusleeping/gx-go
+    - restore_cache:
+        key: dep-v1-{{ checksum "Gopkg.lock" }}-{{ arch }}
+    - restore_cache:
+        key: gx-v1-{{ checksum "package.json" }}-{{ arch }}
+    - run:
+        name: install deps
+        command: |
+          dep ensure
+          ~/go/bin/gx install
+    - save_cache:
+        key: dep-v1-{{ checksum "Gopkg.lock" }}-{{ arch }}
+        paths:
+        - ~/go/src/github.com/textileio/textile-go/vendor
+    - save_cache:
+        key: gx-v1-{{ checksum "package.json" }}-{{ arch }}
+        paths:
+        - ~/go/src/gx
     - run:
         name: install gox
         command: |
           go get github.com/mitchellh/gox
     - run:
+        name: install mingw-w64
+        command: |
+          brew install mingw-w64
+    - run:
         name: cross-compile
         command: |
+          export PATH=$PATH:$GOPATH/bin
           gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64" -output="{{.OS}}-{{.Arch}}"
           CC="x86_64-w64-mingw32-gcc" CXX="x86_64-w64-mingw32-g++" gox -cgo -osarch="windows/amd64" -output="{{.OS}}-{{.Arch}}"
     - run:
@@ -138,14 +171,25 @@ jobs:
         path: ~/dist/cli
 
   build-desktop:
-    docker:
-    - image: textile/builder:1.10.3
-    working_directory: /go/src/github.com/textileio/textile-go
+    macos:
+      xcode: "9.4.0"
+    environment:
+      GOPATH: /Users/distiller/go
+    working_directory: ~/go/src/github.com/textileio/textile-go
     steps:
-    - *checkout-linux
-    - *move-linux-src
-    - *restore-linux-dep-cache
-    - *restore-linux-gx-cache
+    - checkout
+    - run:
+        name: install golang
+        command: |
+          brew install golang
+    - restore_cache:
+        key: dep-v1-{{ checksum "Gopkg.lock" }}-{{ arch }}
+    - restore_cache:
+        key: gx-v1-{{ checksum "package.json" }}-{{ arch }}
+    - run:
+        name: install mingw-w64
+        command: |
+          brew install mingw-w64
     - run:
         name: install astilectron-bundler
         command: |
@@ -153,6 +197,7 @@ jobs:
     - run:
         name: compile
         command: |
+          export PATH=$PATH:$GOPATH/bin
           cd desktop && astilectron-bundler -v
     - run:
         name: collect artifacts
@@ -163,7 +208,7 @@ jobs:
           fi
           OUT=~/dist/desktop
           mkdir -p ${OUT}
-          WD=/go/src/github.com/textileio/textile-go
+          WD=~/go/src/github.com/textileio/textile-go
           cd ${WD}/desktop/output/linux-amd64
           tar -czvf Textile_${VERSION}_linux-amd64.tar.gz Textile
           mv Textile_${VERSION}_linux-amd64.tar.gz ${OUT}/
@@ -183,6 +228,8 @@ jobs:
   build-ios-framework:
     macos:
       xcode: "9.4.0"
+    environment:
+      GOPATH: /Users/distiller/go
     working_directory: ~/go/src/github.com/textileio/textile-go
     steps:
     - checkout
@@ -190,31 +237,10 @@ jobs:
         name: install golang
         command: |
           brew install golang
-    - run:
-        name: install dep
-        command: brew install dep
-    - run:
-        name: install gx
-        command: |
-          go get -u github.com/whyrusleeping/gx
-          go get -u github.com/whyrusleeping/gx-go
     - restore_cache:
         key: dep-v1-{{ checksum "Gopkg.lock" }}-{{ arch }}
     - restore_cache:
         key: gx-v1-{{ checksum "package.json" }}-{{ arch }}
-    - run:
-        name: install deps
-        command: |
-          dep ensure
-          ~/go/bin/gx install
-    - save_cache:
-        key: dep-v1-{{ checksum "Gopkg.lock" }}-{{ arch }}
-        paths:
-        - ~/go/src/github.com/textileio/textile-go/vendor
-    - save_cache:
-        key: gx-v1-{{ checksum "package.json" }}-{{ arch }}
-        paths:
-        - ~/go/src/gx
     - run:
         name: install gomobile
         command: |
@@ -222,7 +248,6 @@ jobs:
     - run:
         name: build ios framework
         command: |
-          export GOPATH=~/go
           export PATH=$PATH:$GOPATH/bin
           gomobile init
           gomobile bind -target=ios/arm64 github.com/textileio/textile-go/mobile
@@ -357,12 +382,14 @@ workflows:
     - build-desktop:
         requires:
         - unit-test
+        - build-cli
         filters:
           tags:
             only: /.*/
     - build-ios-framework:
         requires:
         - unit-test
+        - build-cli
         filters:
           tags:
             only: /.*/

--- a/cmd/cafe.go
+++ b/cmd/cafe.go
@@ -28,6 +28,10 @@ func CafeReferral(c *ishell.Context) {
 	}
 	username, err := core.Node.Wallet.GetUsername()
 	if err != nil {
+		c.Err(err)
+		return
+	}
+	if username == nil {
 		c.Err(errors.New("not logged in"))
 		return
 	}
@@ -35,7 +39,7 @@ func CafeReferral(c *ishell.Context) {
 		Key:         key,
 		Count:       count,
 		Limit:       limit,
-		RequestedBy: username,
+		RequestedBy: *username,
 	}
 	res, err := core.Node.Wallet.CreateReferral(req)
 	if err != nil {

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -147,7 +147,7 @@ func start(a *astilectron.Astilectron, w []*astilectron.Window, _ *astilectron.M
 					username = notification.ActorId
 				}
 				var note = a.NewNotification(&astilectron.NotificationOptions{
-					Title: "#" + notification.Subject,
+					Title: notification.Subject,
 					Body:  fmt.Sprintf("%s %s.", username, notification.Body),
 					Icon:  "/resources/icon.png",
 				})

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -135,7 +135,7 @@ func TestMobile_EmptyThreads(t *testing.T) {
 }
 
 func TestMobile_AddThread(t *testing.T) {
-	itemStr, err := mobile.AddThread("default", "")
+	itemStr, err := mobile.AddThread("default")
 	if err != nil {
 		t.Errorf("add thread failed: %s", err)
 		return
@@ -149,7 +149,7 @@ func TestMobile_AddThread(t *testing.T) {
 }
 
 func TestMobile_Threads(t *testing.T) {
-	itemStr, err := mobile.AddThread("another", "")
+	itemStr, err := mobile.AddThread("another")
 	if err != nil {
 		t.Errorf("add another thread failed: %s", err)
 		return
@@ -277,7 +277,7 @@ func TestMobile_AddPhotoToThread(t *testing.T) {
 }
 
 func TestMobile_SharePhotoToThread(t *testing.T) {
-	itemStr, err := mobile.AddThread("test", "")
+	itemStr, err := mobile.AddThread("test")
 	if err != nil {
 		t.Errorf("add test thread failed: %s", err)
 		return

--- a/mobile/photos.go
+++ b/mobile/photos.go
@@ -161,6 +161,7 @@ func (m *Mobile) GetPhotos(offsetId string, limit int, threadId string) (string,
 		}
 
 		// add comments
+		item.Comments = make([]Comment, 0)
 		ctype := repo.CommentBlock
 		for _, c := range thrd.Blocks("", -1, &ctype, &b.Id) {
 			authorId, err := util.IdFromEncodedPublicKey(c.AuthorPk)
@@ -192,6 +193,7 @@ func (m *Mobile) GetPhotos(offsetId string, limit int, threadId string) (string,
 		}
 
 		// add likes
+		item.Likes = make([]Like, 0)
 		ltype := repo.LikeBlock
 		for _, l := range thrd.Blocks("", -1, &ltype, &b.Id) {
 			authorId, err := util.IdFromEncodedPublicKey(l.AuthorPk)

--- a/mobile/profile.go
+++ b/mobile/profile.go
@@ -53,7 +53,14 @@ func (m *Mobile) GetPubKey() (string, error) {
 
 // GetUsername calls core GetUsername
 func (m *Mobile) GetUsername() (string, error) {
-	return core.Node.Wallet.GetUsername()
+	username, err := core.Node.Wallet.GetUsername()
+	if err != nil {
+		return "", err
+	}
+	if username == nil {
+		return "", nil
+	}
+	return *username, nil
 }
 
 // GetTokens calls core GetTokens
@@ -61,6 +68,9 @@ func (m *Mobile) GetTokens() (string, error) {
 	tokens, err := core.Node.Wallet.GetTokens()
 	if err != nil {
 		return "", err
+	}
+	if tokens == nil {
+		return "", nil
 	}
 	return toJSON(tokens)
 }

--- a/mobile/threads.go
+++ b/mobile/threads.go
@@ -1,6 +1,7 @@
 package mobile
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"github.com/textileio/textile-go/core"
@@ -38,12 +39,12 @@ func (m *Mobile) Threads() (string, error) {
 }
 
 // AddThread adds a new thread with the given name
-func (m *Mobile) AddThread(name string, mnemonic string) (string, error) {
-	var mnem *string
-	if mnemonic != "" {
-		mnem = &mnemonic
+func (m *Mobile) AddThread(name string) (string, error) {
+	sk, _, err := libp2pc.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		return "", err
 	}
-	thrd, _, err := core.Node.Wallet.AddThreadWithMnemonic(name, mnem, true)
+	thrd, err := core.Node.Wallet.AddThread(name, sk, true)
 	if err != nil {
 		return "", err
 	}

--- a/net/service/handlers.go
+++ b/net/service/handlers.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -330,7 +331,11 @@ func (s *TextileService) handleThreadAnnotation(pid peer.ID, pmes *pb.Envelope, 
 		if err != nil {
 			return nil, err
 		}
-		notification.Body = "commented on " + target
+		body, err := thrd.Decrypt(annotation.CaptionCipher)
+		if err != nil {
+			return nil, err
+		}
+		notification.Body = fmt.Sprintf("commented on %s: \"%s\"", target, string(body))
 	case pb.ThreadAnnotation_LIKE:
 		notification, err = buildNotification(thrd.PrivKey, annotation.Header, repo.LikeAddedNotification)
 		if err != nil {

--- a/repo/datastore.go
+++ b/repo/datastore.go
@@ -38,9 +38,9 @@ type ConfigStore interface {
 type ProfileStore interface {
 	SignIn(username string, tokens *CafeTokens) error
 	SignOut() error
-	GetUsername() (string, error)
+	GetUsername() (*string, error)
 	SetAvatarId(id string) error
-	GetAvatarId() (string, error)
+	GetAvatarId() (*string, error)
 	GetTokens() (tokens *CafeTokens, err error)
 }
 

--- a/repo/db/profile_test.go
+++ b/repo/db/profile_test.go
@@ -32,7 +32,7 @@ func TestProfileDB_GetUsername(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if un != "woohoo!" {
+	if *un != "woohoo!" {
 		t.Error("got bad username")
 	}
 }
@@ -50,7 +50,7 @@ func TestProfileDB_GetAvatarId(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if av != "/ipfs/Qm..." {
+	if *av != "/ipfs/Qm..." {
 		t.Error("got bad avatar id")
 	}
 }
@@ -72,13 +72,15 @@ func TestProfileDB_GetTokens(t *testing.T) {
 }
 
 func TestProfileDB_SignOut(t *testing.T) {
-	err := pdb.SignOut()
-	if err != nil {
+	if err := pdb.SignOut(); err != nil {
 		t.Error(err)
 		return
 	}
-	_, err = pdb.GetTokens()
-	if err == nil {
-		t.Error("signed out but username still present")
+	tokens, err := pdb.GetTokens()
+	if err != nil {
+		t.Error(err)
+	}
+	if tokens != nil {
+		t.Error("signed out but tokens still present")
 	}
 }

--- a/wallet/thread/thread.go
+++ b/wallet/thread/thread.go
@@ -50,7 +50,7 @@ type Config struct {
 	Send          func(message *pb.Envelope, peerId string, hash *string) error
 	NewEnvelope   func(message *pb.Message) (*pb.Envelope, error)
 	PutPinRequest func(id string) error
-	GetUsername   func() string
+	GetUsername   func() (*string, error)
 	SendUpdate    func(update Update)
 }
 
@@ -70,7 +70,7 @@ type Thread struct {
 	send          func(message *pb.Envelope, peerId string, hash *string) error
 	newEnvelope   func(message *pb.Message) (*pb.Envelope, error)
 	putPinRequest func(id string) error
-	getUsername   func() string
+	getUsername   func() (*string, error)
 	sendUpdate    func(update Update)
 	mux           sync.Mutex
 }
@@ -306,9 +306,12 @@ func (t *Thread) newBlockHeader() (*pb.ThreadBlockHeader, error) {
 
 	// encrypt our own username with thread pk
 	var authorUnCipher []byte
-	authorUn := t.getUsername()
-	if authorUn != "" {
-		authorUnCipher, err = t.Encrypt([]byte(authorUn))
+	authorUn, err := t.getUsername()
+	if err != nil {
+		return nil, err
+	}
+	if authorUn != nil {
+		authorUnCipher, err = t.Encrypt([]byte(*authorUn))
 		if err != nil {
 			return nil, err
 		}

--- a/wallet/thread/thread.go
+++ b/wallet/thread/thread.go
@@ -306,10 +306,7 @@ func (t *Thread) newBlockHeader() (*pb.ThreadBlockHeader, error) {
 
 	// encrypt our own username with thread pk
 	var authorUnCipher []byte
-	authorUn, err := t.getUsername()
-	if err != nil {
-		return nil, err
-	}
+	authorUn, _ := t.getUsername()
 	if authorUn != nil {
 		authorUnCipher, err = t.Encrypt([]byte(*authorUn))
 		if err != nil {

--- a/wallet/thread_test.go
+++ b/wallet/thread_test.go
@@ -1,9 +1,11 @@
 package wallet_test
 
 import (
+	"crypto/rand"
 	. "github.com/textileio/textile-go/wallet"
 	"github.com/textileio/textile-go/wallet/thread"
 	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
+	libp2pc "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
 	"os"
 	"testing"
 )
@@ -25,6 +27,7 @@ func Test_SetupThread(t *testing.T) {
 	twallet, _, err = NewWallet(wconfig)
 	if err != nil {
 		t.Errorf("create wallet failed: %s", err)
+		return
 	}
 	if err := twallet.Start(); err != nil {
 		t.Errorf("start wallet failed: %s", err)
@@ -32,8 +35,12 @@ func Test_SetupThread(t *testing.T) {
 }
 
 func TestNewThread_WalletOffline(t *testing.T) {
-	var err error
-	thrd, _, err = twallet.AddThreadWithMnemonic("thread1", nil, true)
+	sk, _, err := libp2pc.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	thrd, err = twallet.AddThread("thread1", sk, true)
 	if err != nil {
 		t.Errorf("create thread while offline failed: %s", err)
 	}
@@ -41,8 +48,12 @@ func TestNewThread_WalletOffline(t *testing.T) {
 
 func TestNewThread_WalletOnline(t *testing.T) {
 	<-twallet.Online()
-	var err error
-	_, _, err = twallet.AddThreadWithMnemonic("thread2", nil, true)
+	sk, _, err := libp2pc.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = twallet.AddThread("thread2", sk, true)
 	if err != nil {
 		t.Errorf("create thread while online failed: %s", err)
 	}

--- a/wallet/threads.go
+++ b/wallet/threads.go
@@ -55,24 +55,6 @@ func (w *Wallet) AddThread(name string, secret libp2pc.PrivKey, join bool) (*thr
 	return thrd, nil
 }
 
-// AddThreadWithMnemonic adds a thread with a given name and mnemonic phrase
-func (w *Wallet) AddThreadWithMnemonic(name string, mnemonic *string, join bool) (*thread.Thread, string, error) {
-	if mnemonic != nil {
-		log.Debugf("regenerating keypair from mnemonic for: %s", name)
-	} else {
-		log.Debugf("generating keypair for: %s", name)
-	}
-	secret, mnem, err := util.PrivKeyFromMnemonic(mnemonic)
-	if err != nil {
-		return nil, "", err
-	}
-	thrd, err := w.AddThread(name, secret, join)
-	if err != nil {
-		return nil, "", err
-	}
-	return thrd, mnem, nil
-}
-
 // RemoveThread removes a thread
 func (w *Wallet) RemoveThread(id string) (mh.Multihash, error) {
 	if !w.IsOnline() {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -550,11 +550,8 @@ func (w *Wallet) loadThread(mod *repo.Thread) (*thread.Thread, error) {
 		Send:          w.SendMessage,
 		NewEnvelope:   w.NewEnvelope,
 		PutPinRequest: w.putPinRequest,
-		GetUsername: func() string {
-			username, _ := w.GetUsername()
-			return username
-		},
-		SendUpdate: w.sendThreadUpdate,
+		GetUsername:   w.GetUsername,
+		SendUpdate:    w.sendThreadUpdate,
 	}
 	thrd, err := thread.NewThread(mod, threadConfig)
 	if err != nil {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -167,10 +167,6 @@ func TestWallet_AddThread(t *testing.T) {
 	}
 }
 
-func TestWallet_AddThreadWithMnemonic(t *testing.T) {
-	// TODO
-}
-
 func TestWallet_RemoveThread(t *testing.T) {
 	// TODO
 }


### PR DESCRIPTION
- Fixes #269: Refactored datastore profile methods to not throw sql "no row" errors. This means that on mobile, `GetTokens`, `GetUsername`, and `GetAvatarId` will return empty strings if nothing is found and NO error. (we can't return `nil` because `gobind` doesn't support string pointers.
- Fixes #271 Adds caching to avatars. The mechanism no longer uses a redirect, instead loads content behind the `avatar_id` directly. Expiration set at 2 days.
- Fixes #270 `Comments` and `Likes` will now be empty arrays (not null)
- Removes `AddThreadWithMnemonic`, it's not useful anymore and likely making creating threads slower from mobile, which was wrapping that method. Mobile now uses the normal create thread method, meaning it's signature doesn't have the string param `mnemonic` anymore
- Lastly, adds the actual comment to comment notifications