### PR TITLE
Add directory group option

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -25,11 +25,13 @@ import (
 var errMissingFilePath = errors.New("missing file path")
 var errMissingFileBlockId = errors.New("missing file block id")
 var errNothingToAdd = errors.New("nothing to add")
+var errMissingTarget = errors.New("missing file(s) target")
 
 func init() {
 	register(&addCmd{})
 	register(&lsCmd{})
 	register(&getCmd{})
+	register(&keysCmd{})
 }
 
 const batchSize = 10
@@ -528,6 +530,48 @@ func callGet(args []string) error {
 
 	var info core.ThreadFilesInfo
 	res, err := executeJsonCmd(GET, "files/"+args[0], params{}, &info)
+	if err != nil {
+		return err
+	}
+
+	output(res, nil)
+	return nil
+}
+
+type keysCmd struct {
+	Client ClientOptions `group:"Client Options"`
+}
+
+func (x *keysCmd) Name() string {
+	return "keys"
+}
+
+func (x *keysCmd) Short() string {
+	return "Show file keys"
+}
+
+func (x *keysCmd) Long() string {
+	return `
+Shows file keys under the given target from an add.
+`
+}
+
+func (x *keysCmd) Execute(args []string) error {
+	setApi(x.Client)
+	return callKeys(args)
+}
+
+func (x *keysCmd) Shell() *ishell.Cmd {
+	return nil
+}
+
+func callKeys(args []string) error {
+	if len(args) == 0 {
+		return errMissingTarget
+	}
+
+	var keys core.Keys
+	res, err := executeJsonCmd(GET, "keys/"+args[0], params{}, &keys)
 	if err != nil {
 		return err
 	}

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -57,6 +58,7 @@ type addCmd struct {
 	Client  ClientOptions `group:"Client Options"`
 	Thread  string        `short:"t" long:"thread" description:"Thread ID. Omit for default."`
 	Caption string        `short:"c" long:"caption" description:"File(s) caption."`
+	Group   bool          `short:"g" long:"group" description:"Group directory files."`
 	Verbose bool          `short:"v" long:"verbose" description:"Prints files as they are processed."`
 }
 
@@ -70,7 +72,9 @@ func (x *addCmd) Short() string {
 
 func (x *addCmd) Long() string {
 	return `
-Adds a file or directory to a thread.
+Adds a file or directory of files to a thread. Files not supported 
+by the thread schema are ignored. Nested directories are included.
+Use the --group option to add directory files as a single object.  
 Omit the --thread option to use the default thread (if selected).
 `
 }
@@ -80,6 +84,7 @@ func (x *addCmd) Execute(args []string) error {
 	opts := map[string]string{
 		"thread":  x.Thread,
 		"caption": x.Caption,
+		"group":   strconv.FormatBool(x.Group),
 		"verbose": strconv.FormatBool(x.Verbose),
 	}
 	return callAdd(args, opts)
@@ -94,6 +99,7 @@ func callAdd(args []string, opts map[string]string) error {
 		return errMissingFilePath
 	}
 
+	group := opts["group"] == "true"
 	verbose := opts["verbose"] == "true"
 
 	// fetch schema
@@ -120,10 +126,12 @@ func callAdd(args []string, opts map[string]string) error {
 		return err
 	}
 
+	var pths []string
 	var dirs []core.Directory
+	var count int
+
 	start := time.Now()
 
-	var pths []string
 	if fi.IsDir() {
 		err := filepath.Walk(pth, func(pth string, fi os.FileInfo, err error) error {
 			if fi.IsDir() || fi.Name() == ".DS_Store" {
@@ -135,9 +143,11 @@ func callAdd(args []string, opts map[string]string) error {
 		if err != nil {
 			return err
 		}
-		output(fmt.Sprintf("found %d files", len(pths)), nil)
-
-		tmp := make([]core.Directory, len(pths))
+		msg := fmt.Sprintf("Found %d file", len(pths))
+		if len(pths) != 1 {
+			msg += "s"
+		}
+		output(msg, nil)
 
 		batches := batchPaths(pths, batchSize)
 		for i, batch := range batches {
@@ -145,14 +155,30 @@ func callAdd(args []string, opts map[string]string) error {
 			if err != nil {
 				return err
 			}
-			tmp = append(tmp, res...)
 
-			output(fmt.Sprintf("handled batch %d/%d", i+1, len(batches)), nil)
-		}
+			output(fmt.Sprintf("Milled batch %d/%d", i+1, len(batches)), nil)
 
-		for _, dir := range tmp {
-			if dir != nil {
-				dirs = append(dirs, dir)
+			if group {
+				for _, dir := range res {
+					if dir != nil {
+						dirs = append(dirs, dir)
+						count++
+					}
+				}
+			} else {
+				for _, dir := range res {
+					if dir != nil {
+						caption := strings.TrimSpace(fmt.Sprintf("%s (%d)", opts["caption"], count+1))
+						block, err := add([]core.Directory{dir}, threadId, caption, verbose)
+						if err != nil {
+							return err
+						}
+
+						output(fmt.Sprintf("File %d target: %s", count+1, block.Target), nil)
+
+						count++
+					}
+				}
 			}
 		}
 
@@ -161,40 +187,59 @@ func callAdd(args []string, opts map[string]string) error {
 		if err != nil {
 			return err
 		}
-		dirs = append(dirs, dir)
+
+		block, err := add([]core.Directory{dir}, threadId, opts["caption"], verbose)
+		if err != nil {
+			return err
+		}
+		output(fmt.Sprintf("File target: %s", block.Target), nil)
+
+		count++
 	}
+
+	if group && len(dirs) > 0 {
+		block, err := add(dirs, threadId, opts["caption"], verbose)
+		if err != nil {
+			return err
+		}
+		output(fmt.Sprintf("Group target: %s", block.Target), nil)
+	}
+
 	dur := time.Now().Sub(start)
 
-	if len(dirs) == 0 {
+	if count == 0 {
 		return errNothingToAdd
 	}
 
-	msg := fmt.Sprintf("milled %d file", len(dirs))
-	if len(dirs) != 1 {
+	msg := fmt.Sprintf("Added %d file", count)
+	if count != 1 {
 		msg += "s"
 	}
 	output(fmt.Sprintf("%s in %s", msg, dur.String()), nil)
-	output("posting to thread...", nil)
 
+	return nil
+}
+
+func add(dirs []core.Directory, threadId string, caption string, verbose bool) (*core.BlockInfo, error) {
 	data, err := json.Marshal(&dirs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var block *core.BlockInfo
 	res, err := executeJsonCmd(POST, "threads/"+threadId+"/files", params{
-		opts:    map[string]string{"caption": opts["caption"]},
+		opts:    map[string]string{"caption": caption},
 		payload: bytes.NewReader(data),
 		ctype:   "application/json",
 	}, &block)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	output(res, nil)
-	output("done", nil)
-
-	return nil
+	if verbose {
+		output(res, nil)
+	}
+	return block, nil
 }
 
 func mill(pth string, node *schema.Node, verbose bool) (core.Directory, error) {
@@ -320,15 +365,17 @@ func millBatch(pths []string, node *schema.Node, verbose bool) ([]core.Directory
 	wg := sync.WaitGroup{}
 	for i, pth := range pths {
 		wg.Add(1)
+
 		go func(i int, p string) {
 			dir, err := mill(p, node, verbose)
 			if err != nil {
-				output(err.Error(), nil)
+				output("mill error: "+err.Error(), nil)
 			} else {
 				tmp[i] = dir
 			}
 			wg.Done()
 		}(i, pth)
+
 	}
 	wg.Wait()
 

--- a/core/api.go
+++ b/core/api.go
@@ -105,6 +105,9 @@ func (a *api) Start() {
 		files.GET("", a.lsThreadFiles)
 		files.GET("/:block", a.getThreadFiles)
 
+		keys := v0.Group("/keys")
+		keys.GET("/:target", a.lsThreadFileTargetKeys)
+
 		invites := v0.Group("/invites")
 		invites.POST("", a.createInvites)
 		invites.GET("", a.lsInvites)

--- a/core/api_files.go
+++ b/core/api_files.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/textileio/textile-go/ipfs"
+
 	ipld "gx/ipfs/QmR7TcHkR9nxkUorfi8XMTAMLUK7GiP64TWWBzY3aacc1o/go-ipld-format"
 
 	"github.com/gin-gonic/gin"
@@ -126,4 +128,22 @@ func (a *api) getThreadFiles(g *gin.Context) {
 	}
 
 	g.JSON(http.StatusOK, info)
+}
+
+func (a *api) lsThreadFileTargetKeys(g *gin.Context) {
+	target := g.Param("target")
+
+	node, err := ipfs.NodeAtPath(a.node.Ipfs(), target)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	keys, err := a.node.TargetNodeKeys(node)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	g.JSON(http.StatusOK, keys)
 }

--- a/core/files.go
+++ b/core/files.go
@@ -256,21 +256,26 @@ func (t *Textile) fileNode(file repo.File, dir uio.Directory, link string) error
 		return ErrFileNotFound
 	}
 
-	// include file as well
+	// remove locally indexed targets
+	file.Targets = nil
+
 	plaintext, err := json.Marshal(&file)
 	if err != nil {
 		return err
 	}
+
 	var reader *bytes.Reader
 	if file.Key != "" {
 		key, err := base58.Decode(file.Key)
 		if err != nil {
 			return err
 		}
+
 		ciphertext, err := crypto.EncryptAES(plaintext, key)
 		if err != nil {
 			return err
 		}
+
 		reader = bytes.NewReader(ciphertext)
 	} else {
 		reader = bytes.NewReader(plaintext)
@@ -280,6 +285,7 @@ func (t *Textile) fileNode(file repo.File, dir uio.Directory, link string) error
 	if _, err := ipfs.AddDataToDirectory(t.node, pair, FileLinkName, reader); err != nil {
 		return err
 	}
+
 	if err := ipfs.AddLinkToDirectory(t.node, pair, DataLinkName, file.Hash); err != nil {
 		return err
 	}

--- a/textile.go
+++ b/textile.go
@@ -260,7 +260,7 @@ func (x *initCmd) Execute(args []string) error {
 	if err := core.InitRepo(config); err != nil {
 		return errors.New(fmt.Sprintf("initialize failed: %s", err))
 	}
-	fmt.Printf("ok, address: %s\n", accnt.Address())
+	fmt.Printf("Initialized account with address %s\n", accnt.Address())
 	return nil
 }
 
@@ -276,7 +276,7 @@ func (x *migrateCmd) Execute(args []string) error {
 	}); err != nil {
 		return errors.New(fmt.Sprintf("migrate repo: %s", err))
 	}
-	fmt.Println("repo successfully migrated")
+	fmt.Println("Repo was successfully migrated")
 	return nil
 }
 
@@ -290,8 +290,8 @@ func (x *daemonCmd) Execute(args []string) error {
 	quit := make(chan os.Signal)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
-	fmt.Println("interrupted")
-	fmt.Printf("shutting down...")
+	fmt.Println("Interrupted")
+	fmt.Printf("Shutting down...")
 	if err := stopNode(); err != nil && err != core.ErrStopped {
 		fmt.Println(err.Error())
 	} else {


### PR DESCRIPTION
Previously, the default was to add all files as a single "object"... this makes that non-default, but possible with a `--group` flag.

Also adds a `keys` command for listing keys under a files target.