### PR TITLE
files: fix plaintext opt

### DIFF
--- a/core/main_test.go
+++ b/core/main_test.go
@@ -147,7 +147,7 @@ func TestTextile_AddFile(t *testing.T) {
 	if file.Mill != "/image/resize" {
 		t.Error("wrong mill")
 	}
-	if file.Checksum != "6Em1qNFcc1B3mSToS2aVyubDi7R7w7QedY84eNbiWBW3" {
+	if file.Checksum != "3LLsrJ4zcF66d9r5pMnip243y2zZQpkKShhYVHn4Hk2j" {
 		t.Error("wrong checksum")
 	}
 }

--- a/core/thread.go
+++ b/core/thread.go
@@ -203,6 +203,7 @@ func (t *Thread) Info() (*ThreadInfo, error) {
 		Name:       t.Name,
 		Schema:     t.Schema,
 		SchemaId:   t.schemaId,
+		Initiator:  t.initiator,
 		Type:       mod.Type.Description(),
 		State:      state.Description(),
 		Head:       head,

--- a/mill/blob.go
+++ b/mill/blob.go
@@ -18,8 +18,8 @@ func (m *Blob) AcceptMedia(media string) error {
 	return nil
 }
 
-func (m *Blob) Options() (string, error) {
-	return "", nil
+func (m *Blob) Options(add map[string]interface{}) (string, error) {
+	return hashOpts(make(map[string]string), add)
 }
 
 func (m *Blob) Mill(input []byte, name string) (*Result, error) {

--- a/mill/image_exif.go
+++ b/mill/image_exif.go
@@ -44,8 +44,8 @@ func (m *ImageExif) AcceptMedia(media string) error {
 	}, media)
 }
 
-func (m *ImageExif) Options() (string, error) {
-	return "", nil
+func (m *ImageExif) Options(add map[string]interface{}) (string, error) {
+	return hashOpts(make(map[string]string), add)
 }
 
 func (m *ImageExif) Mill(input []byte, name string) (*Result, error) {

--- a/mill/image_resize.go
+++ b/mill/image_resize.go
@@ -59,8 +59,8 @@ func (m *ImageResize) AcceptMedia(media string) error {
 	}, media)
 }
 
-func (m *ImageResize) Options() (string, error) {
-	return hashOpts(m.Opts)
+func (m *ImageResize) Options(add map[string]interface{}) (string, error) {
+	return hashOpts(m.Opts, add)
 }
 
 func (m *ImageResize) Mill(input []byte, name string) (*Result, error) {

--- a/mill/json.go
+++ b/mill/json.go
@@ -24,8 +24,8 @@ func (m *Json) AcceptMedia(media string) error {
 	}, media)
 }
 
-func (m *Json) Options() (string, error) {
-	return "", nil
+func (m *Json) Options(add map[string]interface{}) (string, error) {
+	return hashOpts(make(map[string]string), add)
 }
 
 func (m *Json) Mill(input []byte, name string) (*Result, error) {

--- a/mill/schema.go
+++ b/mill/schema.go
@@ -25,8 +25,8 @@ func (m *Schema) AcceptMedia(media string) error {
 	return accepts([]string{"application/json"}, media)
 }
 
-func (m *Schema) Options() (string, error) {
-	return "", nil
+func (m *Schema) Options(add map[string]interface{}) (string, error) {
+	return hashOpts(make(map[string]string), add)
 }
 
 func (m *Schema) Mill(input []byte, name string) (*Result, error) {


### PR DESCRIPTION
Needed to add the plaintext option to the opts hash
and the file checksum in order to not catch the same
file with a different plaintext option.