### PR TITLE
service: fail faster on send direct message

### DIFF
--- a/core/cafe_service.go
+++ b/core/cafe_service.go
@@ -244,7 +244,7 @@ func (h *CafeService) DeliverMessage(mid string, pid peer.ID, cafe peer.ID) erro
 	if err != nil {
 		return err
 	}
-	return h.service.SendMessage(cafe, env)
+	return h.service.SendMessage(nil, cafe, env)
 }
 
 // CheckMessages asks each session's inbox for new messages

--- a/core/thread.go
+++ b/core/thread.go
@@ -280,7 +280,7 @@ func (t *Thread) followParents(parents []string) error {
 		}
 
 		if err := t.followParent(hash); err != nil {
-			log.Errorf("failed to follow parent %s: %s", parent, err)
+			log.Warningf("failed to follow parent %s: %s", parent, err)
 			continue
 		}
 	}

--- a/core/thread_service.go
+++ b/core/thread_service.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -158,8 +159,8 @@ func (h *ThreadsService) Handle(pid peer.ID, env *pb.Envelope) (*pb.Envelope, er
 }
 
 // SendMessage sends a message to a peer
-func (h *ThreadsService) SendMessage(pid peer.ID, env *pb.Envelope) error {
-	return h.service.SendMessage(pid, env)
+func (h *ThreadsService) SendMessage(ctx context.Context, pid peer.ID, env *pb.Envelope) error {
+	return h.service.SendMessage(ctx, pid, env)
 }
 
 // NewEnvelope signs and wraps an encypted block for transport

--- a/core/threads_outbox.go
+++ b/core/threads_outbox.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -122,7 +123,9 @@ func (q *ThreadsOutbox) handle(msg repo.ThreadMessage) error {
 	}
 
 	// first, attempt to send the message directly to the recipient
-	if err := q.service().SendMessage(pid, msg.Envelope); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := q.service().SendMessage(ctx, pid, msg.Envelope); err != nil {
 		log.Debugf("send thread message direct to %s failed: %s", pid.Pretty(), err)
 
 		// peer is offline, queue an outbound cafe request for the peer's inbox(es)


### PR DESCRIPTION
Passes a context w/ timeout to the underlying stream creator.