### PR TITLE
outboxes: do not send concurrent to same peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Download the [latest release](https://github.com/textileio/textile-go/releases/l
 
 ## Usage
 
-NOTE: The command line tool currently has limited access to the internal node APIs. We're quickly mapping everything over to a newly designed REST API and command line tool. Stay tuned for docs.
-
 ```
 ~ $ textile --help
 Usage:
@@ -35,22 +33,31 @@ Help Options:
   -h, --help  Show this help message
 
 Available commands:
-  add      Add file(s) to a thread
-  address  Show wallet address
-  cafes    Manage cafes
-  daemon   Start the daemon
-  get      Get a thread file
-  init     Init the node repo and exit
-  invite   Manage thread invites
-  ls       Paginate thread files
-  migrate  Migrate the node repo and exit
-  peer     Show peer ID
-  ping     Ping another peer
-  profile  Manage public profile
-  shell    Start a shell session
-  threads  Manage threads
-  version  Print version and exit
-  wallet   Manage or create an account wallet
+  add            Add file(s) to a thread
+  address        Show wallet address
+  blocks         View thread blocks
+  cafes          Manage cafes
+  chat           Start a thread chat
+  comments       Manage thread comments
+  daemon         Start the daemon
+  get            Get a thread file by ID
+  ignore         Ignore a thread file
+  init           Init the node repo and exit
+  invites        Manage thread invites
+  keys           Show file keys
+  likes          Manage thread likes
+  ls             Paginate thread files
+  messages       Manage thread messages
+  migrate        Migrate the node repo and exit
+  notifications  Manage notifications
+  peer           Show peer ID
+  ping           Ping another peer
+  profile        Manage public profile
+  sub            Subscribe to thread updates
+  swarm          Access IPFS swarm commands
+  threads        Manage threads
+  version        Print version and exit
+  wallet         Manage or create an account wallet
 ```
 
 Textile uses an HD Wallet as an account key manager. You may use the name derived account seed on multiple devices to sync wallet data. To get started, run:

--- a/core/main.go
+++ b/core/main.go
@@ -35,7 +35,7 @@ import (
 var log = logging.Logger("tex-core")
 
 // Version is the core version identifier
-const Version = "1.0.0-rc6"
+const Version = "1.0.0-rc7"
 
 // kQueueFlushFreq how often to flush the message queues
 const kQueueFlushFreq = time.Second * 60

--- a/core/profile.go
+++ b/core/profile.go
@@ -73,7 +73,7 @@ func (t *Textile) SetAvatar(hash string) error {
 	}
 
 	// create a plaintext files thread for tracking avatars
-	thrd := t.ThreadByKey("avatar")
+	thrd := t.ThreadByKey("avatars")
 	if thrd == nil {
 		sk, _, err := libp2pc.GenerateEd25519Key(rand.Reader)
 		if err != nil {

--- a/core/threads.go
+++ b/core/threads.go
@@ -26,6 +26,9 @@ var ErrThreadInviteNotFound = errors.New("thread invite not found")
 // ErrThreadLoaded indicates the thread is already loaded from the datastore
 var ErrThreadLoaded = errors.New("thread is loaded")
 
+// internalThreadKeys lists keys used by internal threads
+var internalThreadKeys = []string{"avatars"}
+
 // AddThreadConfig is used to create a new thread model
 type AddThreadConfig struct {
 	Key       string          `json:"key"`
@@ -129,10 +132,17 @@ func (t *Textile) RemoveThread(id string) (mh.Multihash, error) {
 // Threads lists loaded threads
 func (t *Textile) Threads() []Thread {
 	var threads []Thread
-	for _, t := range t.threads {
-		if t != nil {
-			threads = append(threads, *t)
+loop:
+	for _, i := range t.threads {
+		if i == nil || i.Key == t.account.Address() {
+			continue
 		}
+		for _, k := range internalThreadKeys {
+			if i.Key == k {
+				continue loop
+			}
+		}
+		threads = append(threads, *i)
 	}
 	return threads
 }

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -133,22 +133,6 @@ func TestMobile_Seed(t *testing.T) {
 	}
 }
 
-func TestMobile_CheckAccountThread(t *testing.T) {
-	res, err := mobile1.Threads()
-	if err != nil {
-		t.Errorf("get threads failed: %s", err)
-		return
-	}
-	var threads []core.ThreadInfo
-	if err := json.Unmarshal([]byte(res), &threads); err != nil {
-		t.Error(err)
-		return
-	}
-	if len(threads) != 1 {
-		t.Error("get threads bad result")
-	}
-}
-
 func TestMobile_AddThread(t *testing.T) {
 	res, err := mobile1.AddThread(ksuid.New().String(), "test")
 	if err != nil {
@@ -190,7 +174,7 @@ func TestMobile_Threads(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if len(threads) != 2 {
+	if len(threads) != 1 {
 		t.Error("get threads bad result")
 	}
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@textile/go-mobile",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P.",
-  "version": "1.0.0-rc6",
+  "version": "1.0.0-rc7",
   "author": "textile.io",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "textile-go",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P",
-  "version": "1.0.0-rc6",
+  "version": "1.0.0-rc7",
   "author": "textile.io",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
I'm 90% sure this leads to an occasional message type mismatch for service requests (messages that expect a response).

- Includes a fix for looking up avatars thread to ensure it's only created once (the key was wrong, "avatars" not "avatar")
- Also filters returned threads to not include internal threads (account / avatars)