### PR TITLE
Adds verbosity controls to Textile logs

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,61 @@
+package cmd
+
+import "strconv"
+
+func init() {
+	register(&logsCmd{})
+}
+
+type logsCmd struct {
+	Client    ClientOptions `group:"Client Options"`
+	Subsystem string        `short:"s" long:"subsystem" description:"The subsystem logging identifier. Omit for all."`
+	Level     string        `short:"l" long:"level" description:"The log level, with 'debug' the most verbose and 'critical' the least verbose."`
+	All       bool          `short:"a" long:"all" description:"Whether to list/change only Textile subsystems (default: false), or all available subsystems (true)."`
+}
+
+func (x *logsCmd) Name() string {
+	return "logs"
+}
+
+func (x *logsCmd) Short() string {
+	return "List and control Textile subsystem logs."
+}
+
+func (x *logsCmd) Long() string {
+	return `List or change the verbosity of one or all subsystems log output.
+
+Use the --subsystem option to control a given subsystem's log level. Omit to list/change all subsystems.
+Use the --level option to control the log level. One of: debug, info, warning, error, critical. Omit to get current level.
+Use the --all flag to include all available subsystems. Omit to list/edit Textile subsystems only.
+
+Textile logs piggyback on the IPFS event logs, so this command allows users to control specific subsystem logs for finer control.
+`
+}
+
+func (x *logsCmd) Execute(args []string) error {
+	setApi(x.Client)
+	opts := map[string]string{
+		"subsystem": x.Subsystem,
+		"level":     x.Level,
+		"all":       strconv.FormatBool(x.All),
+	}
+	return callLogs(opts)
+}
+
+func callLogs(opts map[string]string) error {
+	subsystem := opts["subsystem"]
+	if subsystem != "" {
+		subsystem = "/" + subsystem
+	}
+	method := GET
+	if opts["level"] != "" {
+		method = POST
+	}
+	var info []map[string]string
+	res, err := executeJsonCmd(method, "logs"+subsystem, params{opts: opts}, &info)
+	if err != nil {
+		return err
+	}
+	output(res)
+	return nil
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -10,7 +10,7 @@ type logsCmd struct {
 	Client    ClientOptions `group:"Client Options"`
 	Subsystem string        `short:"s" long:"subsystem" description:"The subsystem logging identifier. Omit for all."`
 	Level     string        `short:"l" long:"level" description:"The log level, with 'debug' the most verbose and 'critical' the least verbose."`
-	All       bool          `short:"a" long:"all" description:"Whether to list/change only Textile subsystems (default: false), or all available subsystems (true)."`
+	TexOnly   bool          `short:"t" long:"tex-only" description:"Whether to list/change only Textile subsystems, or all available subsystems."`
 }
 
 func (x *logsCmd) Name() string {
@@ -26,7 +26,7 @@ func (x *logsCmd) Long() string {
 
 Use the --subsystem option to control a given subsystem's log level. Omit to list/change all subsystems.
 Use the --level option to control the log level. One of: debug, info, warning, error, critical. Omit to get current level.
-Use the --all flag to include all available subsystems. Omit to list/edit Textile subsystems only.
+Use the --tex-only flag to list/edit Textile subsystems only, otherwise, include all available subsystems.
 
 Textile logs piggyback on the IPFS event logs, so this command allows users to control specific subsystem logs for finer control.
 `
@@ -37,7 +37,7 @@ func (x *logsCmd) Execute(args []string) error {
 	opts := map[string]string{
 		"subsystem": x.Subsystem,
 		"level":     x.Level,
-		"all":       strconv.FormatBool(x.All),
+		"tex-only":  strconv.FormatBool(x.TexOnly),
 	}
 	return callLogs(opts)
 }
@@ -51,7 +51,7 @@ func callLogs(opts map[string]string) error {
 	if opts["level"] != "" {
 		method = POST
 	}
-	var info []map[string]string
+	var info map[string]string
 	res, err := executeJsonCmd(method, "logs"+subsystem, params{opts: opts}, &info)
 	if err != nil {
 		return err

--- a/core/api.go
+++ b/core/api.go
@@ -182,6 +182,14 @@ func (a *api) Start() {
 			swarm.GET("/peers", a.swarmPeers)
 		}
 
+		logs := v0.Group("/logs")
+		{
+			logs.POST("", a.logsCall)
+			logs.GET("", a.logsCall)
+			logs.POST("/:subsystem", a.logsCall)
+			logs.GET("/:subsystem", a.logsCall)
+		}
+
 	}
 	a.server = &http.Server{
 		Addr:    a.addr,

--- a/core/api_logs.go
+++ b/core/api_logs.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	logging "gx/ipfs/QmZChCsSt8DctjceaL56Eibc29CVQq4dGKRXC5JRZ6Ppae/go-log"
+	logger "gx/ipfs/QmcaSwFc5RBg8yCq54QURwEU4nwjfCpjbpmaAm4VbdGLKv/go-logging"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (a *api) logsCall(g *gin.Context) {
+
+	subsystem := g.Param("subsystem")
+	var subsystems []string
+	if subsystem == "" {
+		subsystems = logging.GetSubsystems()
+	} else {
+		subsystems = []string{subsystem}
+	}
+
+	opts, err := a.readOpts(g)
+	if err != nil {
+		a.abort500(g, err)
+		return
+	}
+	level := strings.ToUpper(opts["level"])
+	all := opts["all"] == "true"
+
+	var result []map[string]string
+	for _, system := range subsystems {
+		if strings.HasPrefix(system, "tex") || all {
+			var llevel logger.Level
+			if level != "" && g.Request.Method == "POST" {
+				// validate log level
+				llevel, err = logger.LogLevel(level)
+				if err != nil {
+					g.String(http.StatusBadRequest, err.Error())
+					return
+				}
+			} else {
+				llevel = logger.GetLevel(system)
+			}
+			// validate subsystem + set log level
+			err = logging.SetLogLevel(system, llevel.String())
+			if err != nil {
+				g.String(http.StatusBadRequest, err.Error())
+				return
+			}
+			result = append(result, map[string]string{system: llevel.String()})
+		}
+	}
+	g.JSON(http.StatusOK, result)
+}

--- a/core/main.go
+++ b/core/main.go
@@ -88,8 +88,9 @@ type MigrateConfig struct {
 
 // RunConfig is used to define run options for a textile node
 type RunConfig struct {
-	PinCode  string
-	RepoPath string
+	PinCode   string
+	RepoPath  string
+	LogLevels map[string]string
 }
 
 // Textile is the main Textile node structure
@@ -133,7 +134,7 @@ func InitRepo(conf InitConfig) error {
 		return ErrAccountRequired
 	}
 
-	setupLogging(conf.RepoPath, conf.LogToDisk)
+	setupLogging(conf.RepoPath, map[string]string{}, conf.LogToDisk)
 
 	// init repo
 	if err := repo.Init(conf.RepoPath, Version); err != nil {
@@ -209,7 +210,7 @@ func NewTextile(conf RunConfig) (*Textile, error) {
 		return nil, err
 	}
 
-	node.writer = setupLogging(conf.RepoPath, node.config.Logs.LogToDisk)
+	node.writer = setupLogging(conf.RepoPath, conf.LogLevels, node.config.Logs.LogToDisk)
 
 	// run all minor repo migrations if needed
 	if err := repo.MigrateUp(conf.RepoPath, conf.PinCode, false); err != nil {
@@ -659,7 +660,7 @@ func (t *Textile) touchDatastore() error {
 }
 
 // setupLogging hijacks the ipfs logging system, putting output to files
-func setupLogging(repoPath string, files bool) io.Writer {
+func setupLogging(repoPath string, logLevels map[string]string, files bool) io.Writer {
 	var writer io.Writer
 	if files {
 		writer = &lumberjack.Logger{
@@ -674,6 +675,10 @@ func setupLogging(repoPath string, files bool) io.Writer {
 	backendFile := logger.NewLogBackend(writer, "", 0)
 	logger.SetBackend(backendFile)
 	logging.SetAllLoggers(logger.ERROR)
+
+	for key, value := range logLevels {
+		logging.SetLogLevel(key, value)
+	}
 
 	return writer
 }

--- a/core/main.go
+++ b/core/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -134,7 +133,7 @@ func InitRepo(conf InitConfig) error {
 		return ErrAccountRequired
 	}
 
-	setupLogging(conf.RepoPath, conf.LogLevel, conf.LogToDisk)
+	setupLogging(conf.RepoPath, conf.LogToDisk)
 
 	// init repo
 	if err := repo.Init(conf.RepoPath, Version); err != nil {
@@ -210,11 +209,7 @@ func NewTextile(conf RunConfig) (*Textile, error) {
 		return nil, err
 	}
 
-	llevel, err := logger.LogLevel(strings.ToUpper(node.config.Logs.LogLevel))
-	if err != nil {
-		llevel = logger.ERROR
-	}
-	node.writer = setupLogging(conf.RepoPath, llevel, node.config.Logs.LogToDisk)
+	node.writer = setupLogging(conf.RepoPath, node.config.Logs.LogToDisk)
 
 	// run all minor repo migrations if needed
 	if err := repo.MigrateUp(conf.RepoPath, conf.PinCode, false); err != nil {
@@ -664,7 +659,7 @@ func (t *Textile) touchDatastore() error {
 }
 
 // setupLogging hijacks the ipfs logging system, putting output to files
-func setupLogging(repoPath string, level logger.Level, files bool) io.Writer {
+func setupLogging(repoPath string, files bool) io.Writer {
 	var writer io.Writer
 	if files {
 		writer = &lumberjack.Logger{
@@ -678,15 +673,7 @@ func setupLogging(repoPath string, level logger.Level, files bool) io.Writer {
 	}
 	backendFile := logger.NewLogBackend(writer, "", 0)
 	logger.SetBackend(backendFile)
-	logging.SetAllLoggers(level)
-
-	// tmp until we have a log command to alter subsystems
-	logging.SetLogLevel("tex-core", "debug")
-	logging.SetLogLevel("tex-service", "debug")
-	logging.SetLogLevel("tex-gateway", "debug")
-	logging.SetLogLevel("tex-ipfs", "debug")
-	logging.SetLogLevel("tex-mill", "debug")
-	logging.SetLogLevel("tex-mobile", "debug")
+	logging.SetAllLoggers(logger.ERROR)
 
 	return writer
 }

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -120,7 +120,6 @@ func Init(version string) (*Config, error) {
 		},
 		Logs: Logs{
 			LogToDisk: true,
-			LogLevel:  "error",
 		},
 		Threads: Threads{
 			Defaults: ThreadDefaults{

--- a/textile.go
+++ b/textile.go
@@ -275,7 +275,15 @@ func (x *migrateCmd) Execute(args []string) error {
 }
 
 func (x *daemonCmd) Execute(args []string) error {
-	if err := buildNode(x.PinCode, x.RepoPath); err != nil {
+	logLevels := make(map[string]string)
+	for _, log := range x.Logs {
+		split := strings.SplitN(log, ":", 2)
+		key := strings.TrimSpace(split[0])
+		value := strings.ToUpper(strings.TrimSpace(split[1]))
+		logLevels[key] = value
+	}
+
+	if err := buildNode(x.PinCode, x.RepoPath, logLevels); err != nil {
 		return err
 	}
 	printSplash()
@@ -313,15 +321,16 @@ func getRepoPath(repoPath string) (string, error) {
 	return repoPath, nil
 }
 
-func buildNode(pinCode string, repoPath string) error {
+func buildNode(pinCode string, repoPath string, logLevels map[string]string) error {
 	repoPathf, err := getRepoPath(repoPath)
 	if err != nil {
 		return err
 	}
 
 	node, err = core.NewTextile(core.RunConfig{
-		PinCode:  pinCode,
-		RepoPath: repoPathf,
+		PinCode:   pinCode,
+		RepoPath:  repoPathf,
+		LogLevels: logLevels,
 	})
 	if err != nil {
 		return errors.New(fmt.Sprintf("create node failed: %s", err))

--- a/textile.go
+++ b/textile.go
@@ -80,8 +80,9 @@ type migrateCmd struct {
 }
 
 type daemonCmd struct {
-	PinCode  string `short:"p" long:"pin-code" description:"Specify the pin code for datastore encryption (omit of none was used during init)."`
-	RepoPath string `short:"r" long:"repo-dir" description:"Specify a custom repository path."`
+	PinCode  string   `short:"p" long:"pin-code" description:"Specify the pin code for datastore encryption (omit of none was used during init)."`
+	RepoPath string   `short:"r" long:"repo-dir" description:"Specify a custom repository path."`
+	Logs     []string `short:"l" long:"logs" description:"Control subcommand log level. e.g., --logs=\"tex-core: debug\" Can be used multiple times."`
 }
 
 var node *core.Textile


### PR DESCRIPTION
Adds verbosity controls to Textile logs for running daemon, as well as when starting a new daemon.

Here is the running daemon command:

```
$ textile logs --help
Usage:
  textile [OPTIONS] logs [logs-OPTIONS]

List or change the verbosity of one or all subsystems log output.

Use the --subsystem option to control a given subsystem's log level. Omit to
list/change all subsystems.
Use the --level option to control the log level. One of: debug, info, warning, error,
critical. Omit to get current level.
Use the --tex-only flag to list/edit Textile subsystems only, otherwise, include all
available subsystems.

Textile logs piggyback on the IPFS event logs, so this command allows users to control
specific subsystem logs for finer control.

Help Options:
  -h, --help             Show this help message

[logs command options]
      -s, --subsystem=   The subsystem logging identifier. Omit for all.
      -l, --level=       The log level, with 'debug' the most verbose and 'critical'
                         the least verbose.
      -t, --tex-only     Whether to list/change only Textile subsystems, or all
                         available subsystems.

    Client Options:
          --api=         API address to use (default: http://127.0.0.1:40600)
          --api-version= API version to use (default: v0)
```

Also added controls to daemon subcommand:

```
$ textile daemon --help
Usage:
  textile [OPTIONS] daemon [daemon-OPTIONS]

Start a node daemon session.

Help Options:
  -h, --help          Show this help message

[daemon command options]
      -p, --pin-code= Specify the pin code for datastore encryption (omit of none was
                      used during init).
      -r, --repo-dir= Specify a custom repository path.
      -l, --logs=     Control subcommand log level. e.g., --logs="tex-core: debug" Can
                      be used multiple times.
```

Here's an example of using `logs` when starting the daemon. Note, the last `logs` flag will be silently ignored because it is a) not a valid subsystem, and b) not valid syntax, whereas the first two are both using valid syntax:

```
$ textile daemon --logs tex-core:debug --logs "tex-ipfs: info" --logs blah: nothing
```