### PR TITLE
Adds ContactUsername to thread, which doesn't have access to parent Textile instance

### DIFF
--- a/core/thread.go
+++ b/core/thread.go
@@ -166,20 +166,11 @@ func (t *Thread) Info() (*ThreadInfo, error) {
 	if mod.Head != "" {
 		h := t.datastore.Blocks().Get(mod.Head)
 		if h != nil {
-			var username string
-			if len(h.AuthorId) >= 7 {
-				username = h.AuthorId[len(h.AuthorId)-7:]
-			}
-			contact := t.datastore.Contacts().Get(h.AuthorId)
-			if contact != nil && contact.Username != "" {
-				username = contact.Username
-			}
-
 			head = &BlockInfo{
 				Id:       h.Id,
 				ThreadId: h.ThreadId,
 				AuthorId: h.AuthorId,
-				Username: username,
+				Username: t.contactUsername(h.AuthorId),
 				Type:     h.Type.Description(),
 				Date:     h.Date,
 				Parents:  h.Parents,
@@ -491,20 +482,11 @@ func (t *Thread) indexBlock(commit *commitResult, blockType repo.BlockType, targ
 	if err := t.datastore.Blocks().Add(index); err != nil {
 		return err
 	}
-
-	var username string
-	if len(index.AuthorId) >= 7 {
-		username = index.AuthorId[len(index.AuthorId)-7:]
-	}
-	contact := t.datastore.Contacts().Get(index.AuthorId)
-	if contact != nil && contact.Username != "" {
-		username = contact.Username
-	}
 	t.pushUpdate(BlockInfo{
 		Id:       index.Id,
 		ThreadId: index.ThreadId,
 		AuthorId: index.AuthorId,
-		Username: username,
+		Username: t.contactUsername(index.AuthorId),
 		Type:     index.Type.Description(),
 		Date:     index.Date,
 		Parents:  index.Parents,
@@ -647,4 +629,21 @@ func loadSchema(node *core.IpfsNode, id string) (*schema.Node, error) {
 		return nil, err
 	}
 	return &sch, nil
+}
+
+// contactUsername returns the username for the peer id if known
+// This is a near-exact port of the Textile version of this method
+func (t *Thread) contactUsername(id string) string {
+	if id == t.node().Identity.Pretty() {
+		username, err := t.datastore.Profile().GetUsername()
+		if err == nil && username != nil && *username != "" {
+			return *username
+		}
+		return ipfs.ShortenID(id)
+	}
+	contact := t.datastore.Contacts().Get(id)
+	if contact == nil {
+		return ipfs.ShortenID(id)
+	}
+	return toUsername(contact)
 }


### PR DESCRIPTION
Since a `Thread` doesn't know about the parent `Textile` instance, the `ContactUsername` method on `Textile` isn't accessible here. This copies that code, and adds it to `Thread`. I would be much nicer to have this in one place, hence why I'm not all that happy with this copy-pasta version, but it works and is simple.