### PR TITLE
Switch to empty interface for JSON `Unmarshal`ing

### DIFF
--- a/mill/json.go
+++ b/mill/json.go
@@ -29,14 +29,14 @@ func (m *Json) Options(add map[string]interface{}) (string, error) {
 }
 
 func (m *Json) Mill(input []byte, name string) (*Result, error) {
-	var any map[string]interface{}
+	var any interface{}
 	if err := json.Unmarshal(input, &any); err != nil {
 		return nil, err
 	}
 
-	if len(any) == 0 {
-		return nil, ErrEmptyJsonFile
-	}
+	// if len(any) == 0 {
+	// 	return nil, ErrEmptyJsonFile
+	// }
 
 	data, err := json.Marshal(&any)
 	if err != nil {

--- a/mill/json.go
+++ b/mill/json.go
@@ -34,10 +34,6 @@ func (m *Json) Mill(input []byte, name string) (*Result, error) {
 		return nil, err
 	}
 
-	// if len(any) == 0 {
-	// 	return nil, ErrEmptyJsonFile
-	// }
-
 	data, err := json.Marshal(&any)
 	if err != nil {
 		return nil, err

--- a/mill/main.go
+++ b/mill/main.go
@@ -13,8 +13,6 @@ var log = logging.Logger("tex-mill")
 
 var ErrMediaTypeNotSupported = errors.New("media type not supported")
 
-var ErrEmptyJsonFile = errors.New("json file is empty")
-
 type Result struct {
 	File []byte
 	Meta map[string]interface{}


### PR DESCRIPTION
This allows us to support _any_ arbitrary top-level JSON primitives, including arrays. Useful for things like JSON Patch, which are arrays of JSON objects describing document modifications:

```
[
  {"op": "add", "path": "/question", "value": "????"}
  {"op": "add", "path": "/answer", "value": 42}
]
```