### PR TITLE
Adds simplified IPFS cat command and api

### DIFF
--- a/cmd/ipfs.go
+++ b/cmd/ipfs.go
@@ -100,6 +100,7 @@ func (x *swarmPeersCmd) Execute(args []string) error {
 
 type ipfsCatCmd struct {
 	Client ClientOptions `group:"Client Options"`
+	Key    string        `short:"k" long:"key" description:"Encyrption key."`
 }
 
 func (x *ipfsCatCmd) Name() string {
@@ -119,7 +120,10 @@ func (x *ipfsCatCmd) Execute(args []string) error {
 	if len(args) == 0 {
 		return errMissingCID
 	}
-	req, err := request(GET, "ipfs/"+args[0], params{})
+
+	req, err := request(GET, "ipfs/"+args[0], params{
+		opts: map[string]string{"key": x.Key},
+	})
 	if err != nil {
 		return err
 	}

--- a/core/api.go
+++ b/core/api.go
@@ -183,6 +183,11 @@ func (a *api) Start() {
 			swarm.GET("/peers", a.swarmPeers)
 		}
 
+		ipfs := v0.Group("/ipfs")
+		{
+			ipfs.GET("/:cid", a.ipfsCat)
+		}
+
 		logs := v0.Group("/logs")
 		{
 			logs.POST("", a.logsCall)

--- a/core/api_ipfs.go
+++ b/core/api_ipfs.go
@@ -46,3 +46,17 @@ func (a *api) swarmPeers(g *gin.Context) {
 
 	g.JSON(http.StatusOK, res)
 }
+
+func (a *api) ipfsCat(g *gin.Context) {
+	cid := g.Param("cid")
+	if cid == "" {
+		g.String(http.StatusBadRequest, "Missing IPFS CID")
+	}
+	res, err := ipfs.DataAtPath(a.node.node, cid)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	g.Data(http.StatusOK, "application/octet-stream", res)
+}


### PR DESCRIPTION
Very simple initial implementation. Open to discussion. Works for my needs.

Questions:

1. Should it more closely mimic the [IPFS cat command](https://docs.ipfs.io/reference/api/cli/#ipfs-cat) (i.e., `offset`, `length`)?
2. Should it also handle IPNS? IPLD? Right now, just adds an `/ipfs/:cid` endpoint to API?
3. Is just `cat`ting raw bytes to console ideal? That's what I need. Should we _not_ accept a key to decrypt?