### PR TITLE
Adds cli and api support for config edits

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -117,6 +117,14 @@
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:90171b862cb6ec187304a593e4d78bfcbcf0f4394870eb66e0eb62cc06b144ad"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
+  version = "v4.1.0"
+
+[[projects]]
   digest = "1:865079840386857c809b72ce300be7580cb50d3d3129ce11bf9aa6ca2bc1934a"
   name = "github.com/fatih/color"
   packages = ["."]
@@ -550,6 +558,7 @@
     "github.com/chzyer/readline",
     "github.com/dgrijalva/jwt-go",
     "github.com/disintegration/imaging",
+    "github.com/evanphx/json-patch",
     "github.com/fatih/color",
     "github.com/gin-contrib/cors",
     "github.com/gin-gonic/gin",

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var errMissingReplacement = errors.New("missing replacement value")
+var errMissingPath = errors.New("missing key path")
+
+func init() {
+	register(&configCmd{})
+}
+
+type configCmd struct {
+	Client ClientOptions `group:"Client Options"`
+}
+
+func (x *configCmd) Name() string {
+	return "config"
+}
+
+func (x *configCmd) Short() string {
+	return "Get and set config values"
+}
+
+func (x *configCmd) Long() string {
+	return `
+The config command controls configuration variables. It works much like 'git config'.
+The configuration values are stored in a config file inside your Textile repository.
+
+When changing values, valid JSON types must be used. For example, a string should be
+escaped or wrapped in single quotes (e.g., \"127.0.0.1:40600\") and arrays and objects
+work fine (e.g. '{"API": "127.0.0.1:40600"}') but should be wrapped in single quotes.
+
+Examples:
+
+Get the value of the 'Addresses.API' key (can also use '/' instead of '.'):
+
+  $ textile config Addresses.API
+
+Print the entire Textile config file to console:
+
+  $ textile config
+
+Set the value of the 'Addresses.API' key:
+
+  $ textile config Addresses.API \"127.0.0.1:40600\"
+`
+}
+
+func (x *configCmd) Execute(args []string) error {
+	setApi(x.Client)
+
+	var path string
+	if len(args) > 0 {
+		path = "/" + strings.Replace(args[0], ".", "/", -1)
+	}
+	if len(args) > 1 {
+		patch := []byte(fmt.Sprintf(`[
+  {"op": "replace", "path": "%s", "value": %s}
+]`, path, args[1]))
+		res, err := request(PATCH, "config", params{
+			payload: bytes.NewBuffer(patch),
+		})
+		if err != nil {
+			return err
+		}
+		defer res.Body.Close()
+		if res.StatusCode >= 400 {
+			res, err := unmarshalString(res.Body)
+			if err != nil {
+				return err
+			}
+			return errors.New(res)
+		}
+		return nil
+	}
+	var info interface{}
+	res, err := executeJsonCmd(GET, "config"+path, params{}, &info)
+	if err != nil {
+		return err
+	}
+	output(res)
+	return nil
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -28,18 +28,28 @@ func (x *configCmd) Short() string {
 
 func (x *configCmd) Long() string {
 	return `
-The config command controls configuration variables. It works much like 'git config'.
-The configuration values are stored in a config file inside your Textile repository.
+The config command controls configuration variables.
+It works much like 'git config'. The configuration
+values are stored in a config file inside your Textile
+repository.
 
-When changing values, valid JSON types must be used. For example, a string should be
-escaped or wrapped in single quotes (e.g., \"127.0.0.1:40600\") and arrays and objects
-work fine (e.g. '{"API": "127.0.0.1:40600"}') but should be wrapped in single quotes.
+Getting config values will report the currently active
+config settings. This may differ from the values specifed
+when setting values.
+
+When changing values, valid JSON types must be used.
+For example, a string should be escaped or wrapped in
+single quotes (e.g., \"127.0.0.1:40600\") and arrays and
+objects work fine (e.g. '{"API": "127.0.0.1:40600"}')
+but should be wrapped in single quotes. Be sure to restart
+the daemon for changes to take effect.
 
 Examples:
 
-Get the value of the 'Addresses.API' key (can also use '/' instead of '.'):
+Get the value of the 'Addresses.API' key:
 
   $ textile config Addresses.API
+  $ textile config Addresses/API # Alternative syntax
 
 Print the entire Textile config file to console:
 
@@ -76,6 +86,7 @@ func (x *configCmd) Execute(args []string) error {
 			}
 			return errors.New(res)
 		}
+		output("Updated! Restart daemon for changes to take effect.")
 		return nil
 	}
 	var info interface{}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,10 +51,11 @@ func register(cmd Cmd) {
 type method string
 
 const (
-	GET  method = "GET"
-	POST method = "POST"
-	PUT  method = "PUT"
-	DEL  method = "DELETE"
+	GET   method = "GET"
+	POST  method = "POST"
+	PUT   method = "PUT"
+	DEL   method = "DELETE"
+	PATCH method = "PATCH"
 )
 
 type params struct {

--- a/core/api.go
+++ b/core/api.go
@@ -196,6 +196,14 @@ func (a *api) Start() {
 			logs.GET("/:subsystem", a.logsCall)
 		}
 
+		config := v0.Group("/config")
+		{
+			config.GET("", a.getConfig)
+			config.PUT("", a.setConfig)
+			config.GET("/*path", a.getConfig)
+			config.PATCH("", a.patchConfig)
+		}
+
 	}
 	a.server = &http.Server{
 		Addr:    a.addr,

--- a/core/api_config.go
+++ b/core/api_config.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"reflect"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/gin-gonic/gin"
+	"github.com/textileio/textile-go/repo/config"
+)
+
+func getKeyValue(path string, object interface{}) (interface{}, error) {
+	keys := strings.Split(path, "/")
+	v := reflect.ValueOf(object)
+	for _, key := range keys {
+		for v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+		if v.Kind() != reflect.Struct {
+			return nil, fmt.Errorf("unable to parse struct path; ecountered %T", v)
+		}
+
+		v = v.FieldByName(key)
+	}
+	return v.Interface(), nil
+}
+
+func (a *api) getConfig(g *gin.Context) {
+	path := g.Param("path")
+	conf := a.node.Config()
+
+	if path == "" {
+		g.JSON(http.StatusOK, conf)
+	} else {
+		value, err := getKeyValue(path[1:], conf)
+		if err != nil {
+			g.String(http.StatusBadRequest, err.Error())
+			return
+		}
+		g.JSON(http.StatusOK, value)
+	}
+}
+
+func (a *api) patchConfig(g *gin.Context) {
+	body, err := ioutil.ReadAll(g.Request.Body)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+	defer g.Request.Body.Close()
+
+	// decode request body into a RFC 6902 patch (array of ops)
+	patch, err := jsonpatch.DecodePatch(body)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	configPath := path.Join(a.node.repoPath, "textile")
+
+	original, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// apply json patch to config
+	modified, err := patch.Apply(original)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// make sure our config is still valid
+	conf := config.Config{}
+	err = json.Unmarshal(modified, &conf)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	json, err := json.MarshalIndent(conf, "", "    ")
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	err = ioutil.WriteFile(configPath, json, 0666)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	g.Writer.WriteHeader(http.StatusNoContent)
+}
+
+func (a *api) setConfig(g *gin.Context) {
+	configPath := path.Join(a.node.repoPath, "textile")
+
+	body, err := ioutil.ReadAll(g.Request.Body)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+	defer g.Request.Body.Close()
+
+	conf := config.Config{}
+	err = json.Unmarshal(body, &conf)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	json, err := json.MarshalIndent(conf, "", "    ")
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	err = ioutil.WriteFile(configPath, json, 0666)
+	if err != nil {
+		g.String(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	g.Writer.WriteHeader(http.StatusNoContent)
+}


### PR DESCRIPTION
Fixes #382.

```
$ textile config --help
Usage:
  textile [OPTIONS] config [config-OPTIONS]

The config command controls configuration variables.
It works much like 'git config'. The configuration
values are stored in a config file inside your Textile
repository.

When changing values, valid JSON types must be used.
For example, a string should be escaped or wrapped in
single quotes (e.g., \"127.0.0.1:40600\") and arrays and
objects work fine (e.g. '{"API": "127.0.0.1:40600"}')
but should be wrapped in single quotes.

Examples:

Get the value of the 'Addresses.API' key:

$ textile config Addresses.API
$ textile config Addresses/API # Alternative syntax

Print the entire Textile config file to console:

$ textile config

Set the value of the 'Addresses.API' key:

$ textile config Addresses.API \"127.0.0.1:40600\"


Help Options:
  -h, --help             Show this help message

[config command options]

    Client Options:
          --api=         API address to use (default: http://127.0.0.1:40600)
          --api-version= API version to use (default: v0)
```

Example:

```
$ textile config Addresses.API
"127.0.0.1:40600"
```
