### PR TITLE
Adds size limits to peer and cafe apis

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -142,6 +142,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:c90367ef15d10d86d6202fc6dc4c5af299bca94eb0cca40d20539612ab2b42cd"
+  name = "github.com/gin-contrib/size"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "76b079a5fce92386efcf161e9f0a14b93d125567"
+
+[[projects]]
+  branch = "master"
   digest = "1:36fe9527deed01d2a317617e59304eb2c4ce9f8a24115bcc5c2e37b3aee5bae4"
   name = "github.com/gin-contrib/sse"
   packages = ["."]
@@ -561,6 +569,7 @@
     "github.com/evanphx/json-patch",
     "github.com/fatih/color",
     "github.com/gin-contrib/cors",
+    "github.com/gin-contrib/size",
     "github.com/gin-gonic/gin",
     "github.com/gin-gonic/gin/render",
     "github.com/golang/protobuf/proto",

--- a/core/api.go
+++ b/core/api.go
@@ -15,6 +15,7 @@ import (
 	"gx/ipfs/QmTRhk7cgjUf2gfQ3p2M9KPECNZEW9XUrmHcFCgog4cPgB/go-libp2p-peer"
 
 	"github.com/gin-contrib/cors"
+	limit "github.com/gin-contrib/size"
 	"github.com/gin-gonic/gin"
 	m "github.com/textileio/textile-go/mill"
 	"github.com/textileio/textile-go/repo"
@@ -69,8 +70,14 @@ func (a *api) Start() {
 		g.Writer.WriteHeader(http.StatusNoContent)
 	})
 
-	// Handle CORS config options
-	router.Use(cors.New(getCORSSettings(a.node.Config())))
+	// middleware
+	conf := a.node.Config()
+	// CORS
+	router.Use(cors.New(getCORSSettings(conf)))
+	// size limits
+	if conf.API.SizeLimit > 0 {
+		router.Use(limit.RequestSizeLimiter(conf.API.SizeLimit))
+	}
 
 	// v0 routes
 	v0 := router.Group("/api/v0")

--- a/core/cafe_api.go
+++ b/core/cafe_api.go
@@ -12,6 +12,7 @@ import (
 	uio "gx/ipfs/QmfB3oNXGGq9S4B2a9YeCajoATms3Zw2VvDm8fK7VeLSV8/go-unixfs/io"
 
 	njwt "github.com/dgrijalva/jwt-go"
+	limit "github.com/gin-contrib/size"
 	"github.com/gin-gonic/gin"
 	"github.com/textileio/textile-go/ipfs"
 	"github.com/textileio/textile-go/jwt"
@@ -67,6 +68,11 @@ func (c *cafeApi) start() {
 	router.GET("/health", func(g *gin.Context) {
 		g.Writer.WriteHeader(http.StatusNoContent)
 	})
+
+	conf := c.node.Config()
+	if conf.Cafe.Host.SizeLimit > 0 {
+		router.Use(limit.RequestSizeLimiter(conf.Cafe.Host.SizeLimit))
+	}
 
 	// v0 routes
 	v0 := router.Group("/cafe/v0")

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -44,6 +44,7 @@ type SwarmPorts struct {
 // API settings
 type API struct {
 	HTTPHeaders map[string][]string // HTTP headers to return with the API.
+	SizeLimit   int64               // Maximum file size limit to accept for POST requests in bytes
 }
 
 // Logs settings
@@ -69,8 +70,9 @@ type Cafe struct {
 
 // TODO: add some more knobs: max num. clients, max client msg age, inbox size, etc.
 type CafeHost struct {
-	Open     bool // when true, other peers can register with this node for cafe services
-	PublicIP string
+	Open      bool // when true, other peers can register with this node for cafe services
+	PublicIP  string
+	SizeLimit int64 // Maximum file size limit to accept for POST requests in bytes
 }
 
 // CafeClient settings
@@ -116,6 +118,7 @@ func Init(version string) (*Config, error) {
 				},
 				"Access-Control-Allow-Origin": {},
 			},
+			SizeLimit: 0,
 		},
 		Logs: Logs{
 			LogToDisk: true,
@@ -127,8 +130,9 @@ func Init(version string) (*Config, error) {
 		},
 		Cafe: Cafe{
 			Host: CafeHost{
-				PublicIP: "",
-				Open:     false,
+				PublicIP:  "",
+				Open:      false,
+				SizeLimit: 0,
 			},
 			Client: CafeClient{
 				Mobile: MobileCafeClient{


### PR DESCRIPTION
This simply adds a new config entry and some checks on the API and CafeAPI Servers. By default, it is non-breaking. So configs without these entries will just default to current behavior, which is to not limit anything. Any config entries > 0 for these will result in limiting the ability to post large files to the server. This is useful for public cafes or peer apis, but is unlikely to be used on mobile.

Changes require no additional tools to take effect. Simply edit the config entries using the config tool. Here's an example:

Start daemon (`textile daemon`), limit to 5MiBs (`textile config API.SizeLimit 5242880`), and then stop and restart (Ctrl+c and `textile daemon`).

Fixes #418 
