### PR TITLE
Single-route HTTP wrapper around the Cafe Service

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/textileio/textile-go/util"
 )
 
 var errMissingReplacement = errors.New("missing replacement value")
@@ -80,7 +82,7 @@ func (x *configCmd) Execute(args []string) error {
 		}
 		defer res.Body.Close()
 		if res.StatusCode >= 400 {
-			res, err := unmarshalString(res.Body)
+			res, err := util.UnmarshalString(res.Body)
 			if err != nil {
 				return err
 			}

--- a/cmd/ipfs.go
+++ b/cmd/ipfs.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/textileio/textile-go/ipfs"
+	"github.com/textileio/textile-go/util"
 )
 
 var errMissingMultiAddress = errors.New("missing peer multi address")
@@ -129,12 +130,14 @@ func (x *ipfsCatCmd) Execute(args []string) error {
 	}
 	defer req.Body.Close()
 	if req.StatusCode >= 400 {
-		res, err := unmarshalString(req.Body)
+		res, err := util.UnmarshalString(req.Body)
 		if err != nil {
 			return err
 		}
 		return errors.New(res)
 	}
-	io.Copy(os.Stdout, req.Body)
+	if _, err := io.Copy(os.Stdout, req.Body); err != nil {
+		return err
+	}
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/fatih/color"
+
+	"github.com/textileio/textile-go/util"
 )
 
 type ClientOptions struct {
@@ -71,7 +72,7 @@ func executeStringCmd(meth method, pth string, pars params) (string, error) {
 		return "", err
 	}
 	defer req.Body.Close()
-	res, err := unmarshalString(req.Body)
+	res, err := util.UnmarshalString(req.Body)
 	if err != nil {
 		return "", err
 	}
@@ -85,13 +86,13 @@ func executeJsonCmd(meth method, pth string, pars params, target interface{}) (s
 	}
 	defer req.Body.Close()
 	if req.StatusCode >= 400 {
-		res, err := unmarshalString(req.Body)
+		res, err := util.UnmarshalString(req.Body)
 		if err != nil {
 			return "", err
 		}
 		return "", errors.New(res)
 	}
-	if err := unmarshalJSON(req.Body, target); err != nil {
+	if err := util.UnmarshalJSON(req.Body, target); err != nil {
 		return "", err
 	}
 	data, err := json.MarshalIndent(target, "", "    ")
@@ -128,39 +129,6 @@ func request(meth method, pth string, pars params) (*http.Response, error) {
 	return client.Do(req)
 }
 
-func unmarshalString(body io.ReadCloser) (string, error) {
-	data, err := ioutil.ReadAll(body)
-	if err != nil {
-		return "", err
-	}
-	return trimQuotes(string(data)), nil
-}
-
-func unmarshalJSON(body io.ReadCloser, target interface{}) error {
-	data, err := ioutil.ReadAll(body)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, target)
-}
-
 func output(value interface{}) {
 	fmt.Println(value)
-}
-
-func trimQuotes(s string) string {
-	if len(s) > 0 && s[0] == '"' {
-		s = s[1:]
-	}
-	if len(s) > 0 && s[len(s)-1] == '"' {
-		s = s[:len(s)-1]
-	}
-	return s
-}
-
-func printSplash(version string) {
-	url := fmt.Sprintf("%s/api/%s", apiAddr, apiVersion)
-	fmt.Println(Grey("Textile shell version v" + version))
-	fmt.Println(Grey("Textile API: " + url))
-	fmt.Println(Grey("type 'help' for available commands"))
 }

--- a/cmd/sub.go
+++ b/cmd/sub.go
@@ -5,9 +5,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/textileio/textile-go/util"
-
 	"github.com/textileio/textile-go/core"
+	"github.com/textileio/textile-go/util"
 )
 
 func init() {

--- a/cmd/sub.go
+++ b/cmd/sub.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/textileio/textile-go/util"
+
 	"github.com/textileio/textile-go/core"
 )
 
@@ -76,7 +78,6 @@ func (x *subCmd) Execute(args []string) error {
 			output(string(data))
 		}
 	}
-	return nil
 }
 
 func callSub(threadId string, types []string) (<-chan core.ThreadUpdate, error) {
@@ -96,7 +97,7 @@ func callSub(threadId string, types []string) (<-chan core.ThreadUpdate, error) 
 		}
 
 		if req.StatusCode >= 400 {
-			res, err := unmarshalString(req.Body)
+			res, err := util.UnmarshalString(req.Body)
 			if err != nil {
 				output(err.Error())
 			} else {

--- a/core/api.go
+++ b/core/api.go
@@ -242,7 +242,6 @@ func (a *api) Start() {
 
 // Stop stops the http api
 func (a *api) Stop() error {
-	// Use timeout to force a deadline
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := a.server.Shutdown(ctx); err != nil {

--- a/core/cafe_api.go
+++ b/core/cafe_api.go
@@ -229,16 +229,12 @@ func (c *cafeApi) pin(g *gin.Context) {
 	})
 }
 
+// service is an HTTP entry point for the cafe service
 func (c *cafeApi) service(g *gin.Context) {
 	if !c.node.Online() {
 		g.AbortWithStatusJSON(http.StatusInternalServerError, PinResponse{
 			Error: "node is offline",
 		})
-		return
-	}
-
-	// validate request token
-	if !c.tokenValid(g) {
 		return
 	}
 

--- a/core/cafe_api.go
+++ b/core/cafe_api.go
@@ -4,9 +4,16 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"gx/ipfs/QmTRhk7cgjUf2gfQ3p2M9KPECNZEW9XUrmHcFCgog4cPgB/go-libp2p-peer"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin/render"
+	"github.com/golang/protobuf/proto"
+	"github.com/textileio/textile-go/pb"
 
 	"gx/ipfs/QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7/go-cid"
 	uio "gx/ipfs/QmfB3oNXGGq9S4B2a9YeCajoATms3Zw2VvDm8fK7VeLSV8/go-unixfs/io"
@@ -72,6 +79,7 @@ func (c *cafeApi) start() {
 	v0 := router.Group("/cafe/v0")
 	{
 		v0.POST("/pin", c.pin)
+		v0.POST("/service", c.service)
 	}
 	c.server = &http.Server{
 		Addr:    c.addr,
@@ -103,12 +111,12 @@ func (c *cafeApi) start() {
 
 // stop stops the cafe api
 func (c *cafeApi) stop() error {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	if err := c.server.Shutdown(ctx); err != nil {
 		log.Errorf("error shutting down cafe api: %s", err)
 		return err
 	}
-	cancel()
 	return nil
 }
 
@@ -137,29 +145,14 @@ func (c *cafeApi) pin(g *gin.Context) {
 		})
 		return
 	}
-	var id cid.Cid
 
-	// get the auth token
-	auth := strings.Split(g.Request.Header.Get("Authorization"), " ")
-	if len(auth) < 2 {
-		g.AbortWithStatusJSON(http.StatusUnauthorized, unauthorizedResponse)
-		return
-	}
-	token := auth[1]
-
-	// validate token
-	proto := string(c.node.cafeService.Protocol())
-	if err := jwt.Validate(token, c.verifyKeyFunc, false, proto, nil); err != nil {
-		switch err {
-		case jwt.ErrNoToken, jwt.ErrExpired:
-			g.AbortWithStatusJSON(http.StatusUnauthorized, unauthorizedResponse)
-		case jwt.ErrInvalid:
-			g.AbortWithStatusJSON(http.StatusForbidden, forbiddenResponse)
-		}
+	// validate request token
+	if !c.tokenValid(g) {
 		return
 	}
 
 	// handle based on content type
+	var id cid.Cid
 	cType := g.Request.Header.Get("Content-Type")
 	switch cType {
 	case "application/gzip":
@@ -235,6 +228,95 @@ func (c *cafeApi) pin(g *gin.Context) {
 	g.JSON(http.StatusCreated, PinResponse{
 		Id: hash,
 	})
+}
+
+func (c *cafeApi) service(g *gin.Context) {
+	if !c.node.Online() {
+		g.AbortWithStatusJSON(http.StatusInternalServerError, PinResponse{
+			Error: "node is offline",
+		})
+		return
+	}
+
+	// validate request token
+	if !c.tokenValid(g) {
+		return
+	}
+
+	body, err := ioutil.ReadAll(g.Request.Body)
+	if err != nil {
+		g.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// parse body as a service envelope
+	pmes := new(pb.Envelope)
+	if err := proto.Unmarshal(body, pmes); err != nil {
+		g.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	peerId := g.Request.Header.Get("X-Textile-Peer")
+	if peerId == "" {
+		g.AbortWithStatusJSON(http.StatusBadRequest, "missing peer ID")
+		return
+	}
+	mPeer, err := peer.IDB58Decode(peerId)
+	if err != nil {
+		g.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := c.node.cafeService.service.VerifyEnvelope(pmes, mPeer); err != nil {
+		g.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+	}
+
+	// handle the message as normal
+	log.Debugf("received %s from %s", pmes.Message.Type.String(), mPeer.Pretty())
+	rpmes, err := c.node.cafeService.Handle(mPeer, pmes)
+	if err != nil {
+		g.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if rpmes == nil {
+		g.Status(200)
+		return
+	}
+
+	// send out response msg
+	log.Debugf("responding with %s to %s", rpmes.Message.Type.String(), mPeer.Pretty())
+
+	res, err := proto.Marshal(rpmes)
+	if err != nil {
+		g.AbortWithStatusJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// ship it
+	g.Render(200, render.Data{Data: res})
+}
+
+// validToken aborts the request if the token is invalid
+func (c *cafeApi) tokenValid(g *gin.Context) bool {
+	auth := strings.Split(g.Request.Header.Get("Authorization"), " ")
+	if len(auth) < 2 {
+		g.AbortWithStatusJSON(http.StatusUnauthorized, unauthorizedResponse)
+		return false
+	}
+	token := auth[1]
+
+	protocol := string(c.node.cafeService.Protocol())
+	if err := jwt.Validate(token, c.verifyKeyFunc, false, protocol, nil); err != nil {
+		switch err {
+		case jwt.ErrNoToken, jwt.ErrExpired:
+			g.AbortWithStatusJSON(http.StatusUnauthorized, unauthorizedResponse)
+		case jwt.ErrInvalid:
+			g.AbortWithStatusJSON(http.StatusForbidden, forbiddenResponse)
+		}
+		return false
+	}
+	return true
 }
 
 // verifyKeyFunc returns the correct key for token verification

--- a/core/cafe_api.go
+++ b/core/cafe_api.go
@@ -4,24 +4,23 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"gx/ipfs/QmTRhk7cgjUf2gfQ3p2M9KPECNZEW9XUrmHcFCgog4cPgB/go-libp2p-peer"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin/render"
-	"github.com/golang/protobuf/proto"
-	"github.com/textileio/textile-go/pb"
-
 	"gx/ipfs/QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7/go-cid"
+	"gx/ipfs/QmTRhk7cgjUf2gfQ3p2M9KPECNZEW9XUrmHcFCgog4cPgB/go-libp2p-peer"
 	uio "gx/ipfs/QmfB3oNXGGq9S4B2a9YeCajoATms3Zw2VvDm8fK7VeLSV8/go-unixfs/io"
 
 	njwt "github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/render"
+	"github.com/golang/protobuf/proto"
 	"github.com/textileio/textile-go/ipfs"
 	"github.com/textileio/textile-go/jwt"
+	"github.com/textileio/textile-go/pb"
 )
 
 // cafeApiVersion is the cafe api version

--- a/core/cafe_service.go
+++ b/core/cafe_service.go
@@ -335,23 +335,28 @@ func (h *CafeService) sendCafeRequest(
 	if session == nil {
 		return nil, errors.New(fmt.Sprintf("could not find session for cafe %s", cafe.Pretty()))
 	}
+
 	env, err := envFactory(session)
 	if err != nil {
 		return nil, err
 	}
 
-	renv, err := h.service.SendRequest(cafe, env)
+	addr := fmt.Sprintf("http://%s/cafe/%s/service", session.HttpAddr, cafeApiVersion)
+	renv, err := h.service.SendHTTPRequest(addr, session.Access, env)
 	if err != nil {
 		if err.Error() == errUnauthorized {
 			refreshed, err := h.refresh(session)
 			if err != nil {
 				return nil, err
 			}
+
 			env, err := envFactory(refreshed)
 			if err != nil {
 				return nil, err
 			}
-			renv, err = h.service.SendRequest(cafe, env)
+
+			addr := fmt.Sprintf("http://%s/cafe/%s/service", session.HttpAddr, cafeApiVersion)
+			renv, err = h.service.SendHTTPRequest(addr, session.Access, env)
 			if err != nil {
 				return nil, err
 			}

--- a/core/cafe_service.go
+++ b/core/cafe_service.go
@@ -165,12 +165,14 @@ func (h *CafeService) Store(cids []string, cafe peer.ID) ([]string, error) {
 	var stored []string
 
 	var accessToken string
+	var addr string
 	renv, err := h.sendCafeRequest(cafe, func(session *repo.CafeSession) (*pb.Envelope, error) {
 		store := &pb.CafeStore{
 			Token: session.Access,
 			Cids:  cids,
 		}
 		accessToken = session.Access
+		addr = fmt.Sprintf("http://%s/cafe/%s/service", session.HttpAddr, cafeApiVersion)
 		return h.service.NewEnvelope(pb.Message_CAFE_STORE, store, nil, false)
 	})
 	if err != nil {
@@ -207,7 +209,7 @@ loop:
 		if err != nil {
 			return stored, err
 		}
-		if err := h.sendBlock(decoded, cafe, accessToken); err != nil {
+		if err := h.sendObject(decoded, addr, accessToken); err != nil {
 			return stored, err
 		}
 		stored = append(stored, id)
@@ -250,6 +252,11 @@ func (h *CafeService) StoreThread(thrd *repo.Thread, cafe peer.ID) error {
 // DeliverMessage delivers a message content id to a peer's cafe inbox
 // TODO: unpin message locally after it's delivered
 func (h *CafeService) DeliverMessage(mid string, pid peer.ID, cafe peer.ID) error {
+	session := h.datastore.CafeSessions().Get(cafe.Pretty())
+	if session == nil {
+		return errors.New(fmt.Sprintf("could not find session for cafe %s", cafe.Pretty()))
+	}
+
 	env, err := h.service.NewEnvelope(pb.Message_CAFE_DELIVER_MESSAGE, &pb.CafeDeliverMessage{
 		Id:       mid,
 		ClientId: pid.Pretty(),
@@ -257,7 +264,9 @@ func (h *CafeService) DeliverMessage(mid string, pid peer.ID, cafe peer.ID) erro
 	if err != nil {
 		return err
 	}
-	return h.service.SendMessage(nil, cafe, env)
+
+	addr := fmt.Sprintf("http://%s/cafe/%s/service", session.HttpAddr, cafeApiVersion)
+	return h.service.SendHTTPMessage(addr, env)
 }
 
 // CheckMessages asks each session's inbox for new messages
@@ -342,7 +351,7 @@ func (h *CafeService) sendCafeRequest(
 	}
 
 	addr := fmt.Sprintf("http://%s/cafe/%s/service", session.HttpAddr, cafeApiVersion)
-	renv, err := h.service.SendHTTPRequest(addr, session.Access, env)
+	renv, err := h.service.SendHTTPRequest(addr, env)
 	if err != nil {
 		if err.Error() == errUnauthorized {
 			refreshed, err := h.refresh(session)
@@ -356,7 +365,7 @@ func (h *CafeService) sendCafeRequest(
 			}
 
 			addr := fmt.Sprintf("http://%s/cafe/%s/service", session.HttpAddr, cafeApiVersion)
-			renv, err = h.service.SendHTTPRequest(addr, session.Access, env)
+			renv, err = h.service.SendHTTPRequest(addr, env)
 			if err != nil {
 				return nil, err
 			}
@@ -429,8 +438,8 @@ func (h *CafeService) refresh(session *repo.CafeSession) (*repo.CafeSession, err
 	return refreshed, nil
 }
 
-// sendBlock sends data by cid to a peer
-func (h *CafeService) sendBlock(id cid.Cid, pid peer.ID, token string) error {
+// sendObject sends data or an object by cid to a peer
+func (h *CafeService) sendObject(id cid.Cid, addr string, token string) error {
 	obj := &pb.CafeObject{
 		Token: token,
 		Cid:   id.Hash().B58String(),
@@ -456,7 +465,7 @@ func (h *CafeService) sendBlock(id cid.Cid, pid peer.ID, token string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := h.service.SendRequest(pid, env); err != nil {
+	if _, err := h.service.SendHTTPRequest(addr, env); err != nil {
 		return err
 	}
 	return nil

--- a/core/main.go
+++ b/core/main.go
@@ -34,7 +34,7 @@ import (
 var log = logging.Logger("tex-core")
 
 // Version is the core version identifier
-const Version = "1.0.0-rc14"
+const Version = "1.0.0-rc15"
 
 // kQueueFlushFreq how often to flush the message queues
 const kQueueFlushFreq = time.Second * 60

--- a/core/threads_outbox.go
+++ b/core/threads_outbox.go
@@ -139,7 +139,7 @@ func (q *ThreadsOutbox) handle(pid peer.ID, msg repo.ThreadMessage) error {
 		// peer is offline, queue an outbound cafe request for the peer's inbox(es)
 		contact := q.datastore.Contacts().Get(pid.Pretty())
 		if contact != nil && len(contact.Inboxes) > 0 {
-			log.Debugf("send thread message for %s to inbox(es)", pid.Pretty())
+			log.Debugf("sending thread message for %s to inbox(es)", pid.Pretty())
 
 			// add an inbox request for message delivery
 			if err := q.cafeOutbox.InboxRequest(pid, msg.Envelope, contact.Inboxes); err != nil {

--- a/ipfs/api.go
+++ b/ipfs/api.go
@@ -30,7 +30,7 @@ import (
 var log = logging.Logger("tex-ipfs")
 
 const pinTimeout = time.Minute
-const catTimeout = time.Second * 30
+const catTimeout = time.Minute
 const ipnsTimeout = time.Second * 30
 const connectTimeout = time.Second * 10
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@textile/go-mobile",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P.",
-  "version": "1.0.0-rc14",
+  "version": "1.0.0-rc15",
   "author": "textile.io",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "textile-go",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P.",
-  "version": "1.0.0-rc14",
+  "version": "1.0.0-rc15",
   "author": "textile.io",
   "license": "MIT",
   "repository": {

--- a/service/main.go
+++ b/service/main.go
@@ -125,8 +125,10 @@ func (srv *Service) SendRequest(p peer.ID, pmes *pb.Envelope) (*pb.Envelope, err
 }
 
 // SendHTTPRequest sends a request over HTTP
-func (srv *Service) SendHTTPRequest(addr string, token string, env *pb.Envelope) (*pb.Envelope, error) {
-	payload, err := proto.Marshal(env)
+func (srv *Service) SendHTTPRequest(addr string, token string, pmes *pb.Envelope) (*pb.Envelope, error) {
+	log.Debugf("sending %s to %s", pmes.Message.Type.String(), addr)
+
+	payload, err := proto.Marshal(pmes)
 	if err != nil {
 		return nil, err
 	}
@@ -162,12 +164,14 @@ func (srv *Service) SendHTTPRequest(addr string, token string, env *pb.Envelope)
 		return nil, nil
 	}
 
-	renv := new(pb.Envelope)
-	if err := proto.Unmarshal(body, renv); err != nil {
+	rpmes := new(pb.Envelope)
+	if err := proto.Unmarshal(body, rpmes); err != nil {
 		return nil, err
 	}
 
-	return renv, nil
+	log.Debugf("received %s response from %s", rpmes.Message.Type.String(), addr)
+
+	return rpmes, nil
 }
 
 // SendMessage sends out a message

--- a/service/main.go
+++ b/service/main.go
@@ -2,11 +2,14 @@ package service
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
+	"net/http"
 	"sync"
 	"time"
 
@@ -24,6 +27,7 @@ import (
 	"github.com/textileio/textile-go/crypto"
 	"github.com/textileio/textile-go/keypair"
 	"github.com/textileio/textile-go/pb"
+	"github.com/textileio/textile-go/util"
 )
 
 var log = logging.Logger("tex-service")
@@ -90,8 +94,7 @@ func (srv *Service) Ping(p peer.ID) (PeerStatus, error) {
 	return PeerOnline, nil
 }
 
-// SendRequest sends out a request, but also makes sure to
-// measure the RTT for latency measurements.
+// SendRequest sends out a request
 func (srv *Service) SendRequest(p peer.ID, pmes *pb.Envelope) (*pb.Envelope, error) {
 	log.Debugf("sending %s to %s", pmes.Message.Type.String(), p.Pretty())
 
@@ -119,6 +122,52 @@ func (srv *Service) SendRequest(p peer.ID, pmes *pb.Envelope) (*pb.Envelope, err
 	}
 
 	return rpmes, nil
+}
+
+// SendHTTPRequest sends a request over HTTP
+func (srv *Service) SendHTTPRequest(addr string, token string, env *pb.Envelope) (*pb.Envelope, error) {
+	payload, err := proto.Marshal(env)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", addr, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Textile-Peer", srv.Node.Identity.Pretty())
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		res, err := util.UnmarshalString(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New(res)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	renv := new(pb.Envelope)
+	if err := proto.Unmarshal(body, renv); err != nil {
+		return nil, err
+	}
+
+	return renv, nil
 }
 
 // SendMessage sends out a message

--- a/util/main.go
+++ b/util/main.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+)
+
+func UnmarshalString(body io.ReadCloser) (string, error) {
+	data, err := ioutil.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
+	return trimQuotes(string(data)), nil
+}
+
+func UnmarshalJSON(body io.ReadCloser, target interface{}) error {
+	data, err := ioutil.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, target)
+}
+
+func trimQuotes(s string) string {
+	if len(s) > 0 && s[0] == '"' {
+		s = s[1:]
+	}
+	if len(s) > 0 && s[len(s)-1] == '"' {
+		s = s[:len(s)-1]
+	}
+	return s
+}


### PR DESCRIPTION
Pretty simple because all the auth, handler choosing, etc. is done in the service layer. So, really just have to send the message envelopes in the request body, unmarshal them, handle, then marshal the response envelope as the HTTP response.