### PR TITLE
cafe: show more info

### DIFF
--- a/core/cafe_api.go
+++ b/core/cafe_api.go
@@ -67,8 +67,11 @@ func (c *cafeApi) start() {
 	router := gin.Default()
 	router.GET("/", func(g *gin.Context) {
 		g.JSON(http.StatusOK, gin.H{
-			"cafe_version": cafeApiVersion,
-			"node_version": Version,
+			"peer_id":  c.node.node.Identity.Pretty(),
+			"address":  c.node.config.Account.Address,
+			"api":      cafeApiVersion,
+			"protocol": string(c.node.cafeService.Protocol()),
+			"node":     Version,
 		})
 	})
 	router.GET("/health", func(g *gin.Context) {

--- a/core/main.go
+++ b/core/main.go
@@ -34,7 +34,7 @@ import (
 var log = logging.Logger("tex-core")
 
 // Version is the core version identifier
-const Version = "1.0.0-rc18"
+const Version = "1.0.0-rc19"
 
 // kQueueFlushFreq how often to flush the message queues
 const kQueueFlushFreq = time.Second * 60

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@textile/go-mobile",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P.",
-  "version": "1.0.0-rc18",
+  "version": "1.0.0-rc19",
   "author": "textile.io",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "textile-go",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P.",
-  "version": "1.0.0-rc18",
+  "version": "1.0.0-rc19",
   "author": "textile.io",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This just shows more info at the root of the Cafe HTTP API:
```
{
    "address": "P9LdjP925rziPUQksu5NxBBBBeohdEC8iEFAeRw7FR92y3XT",
    "api": "v0",
    "node": "1.0.0-rc19",
    "peer_id": "12D3KooWHBYAGvNesfUCJViiyQL8LnkgLQBsikW9fYEXYg6mC1f8",
    "protocol": "/textile/cafe/1.0.0"
}
```