### PR TITLE
contacts: fix bad joins

### DIFF
--- a/core/contacts.go
+++ b/core/contacts.go
@@ -79,8 +79,8 @@ func (t *Textile) ContactUsername(id string) string {
 		}
 		return ipfs.ShortenID(id)
 	}
-	contact := t.datastore.Contacts().Get(id)
-	if contact == nil {
+	contact, err := t.contact(id)
+	if contact == nil || err != nil {
 		return ipfs.ShortenID(id)
 	}
 	return toUsername(contact)
@@ -201,4 +201,27 @@ func repoContactToProto(rep *repo.Contact) *pb.Contact {
 		Created:  created,
 		Updated:  updated,
 	}
+}
+
+// tmp
+func (t *Textile) contact(id string) (*repo.Contact, error) {
+	self := t.node.Identity.Pretty()
+	if id == self {
+		prof, err := t.Profile(t.node.Identity)
+		if err != nil || prof == nil {
+			return nil, err
+		}
+
+		return &repo.Contact{
+			Id:       self,
+			Address:  prof.Address,
+			Username: prof.Username,
+			Avatar:   strings.Replace(prof.AvatarUri, "/ipfs/", "", 1),
+			Inboxes:  prof.Inboxes,
+			Created:  time.Now(),
+			Updated:  time.Now(),
+		}, nil
+	}
+
+	return t.datastore.Contacts().Get(id), nil
 }

--- a/core/main.go
+++ b/core/main.go
@@ -34,7 +34,7 @@ import (
 var log = logging.Logger("tex-core")
 
 // Version is the core version identifier
-const Version = "1.0.0-rc25"
+const Version = "1.0.0-rc26"
 
 // kQueueFlushFreq how often to flush the message queues
 const kQueueFlushFreq = time.Second * 60
@@ -591,6 +591,7 @@ func (t *Textile) loadThread(mod *repo.Thread) (*Thread, error) {
 		ThreadsOutbox: t.threadsOutbox,
 		CafeOutbox:    t.cafeOutbox,
 		SendUpdate:    t.sendThreadUpdate,
+		GetContact:    t.contact,
 	}
 
 	thrd, err := NewThread(mod, threadConfig)

--- a/core/thread.go
+++ b/core/thread.go
@@ -97,6 +97,7 @@ type ThreadConfig struct {
 	ThreadsOutbox *ThreadsOutbox
 	CafeOutbox    *CafeOutbox
 	SendUpdate    func(update ThreadUpdate)
+	GetContact    func(id string) (*repo.Contact, error)
 }
 
 // Thread is the primary mechanism representing a collecion of data / files / photos
@@ -117,6 +118,7 @@ type Thread struct {
 	threadsOutbox *ThreadsOutbox
 	cafeOutbox    *CafeOutbox
 	sendUpdate    func(update ThreadUpdate)
+	getContact    func(id string) (*repo.Contact, error)
 	mux           sync.Mutex
 }
 
@@ -152,6 +154,7 @@ func NewThread(model *repo.Thread, conf *ThreadConfig) (*Thread, error) {
 		threadsOutbox: conf.ThreadsOutbox,
 		cafeOutbox:    conf.CafeOutbox,
 		sendUpdate:    conf.SendUpdate,
+		getContact:    conf.GetContact,
 	}, nil
 }
 
@@ -619,8 +622,8 @@ func (t *Thread) contactUsername(id string) string {
 		}
 		return ipfs.ShortenID(id)
 	}
-	contact := t.datastore.Contacts().Get(id)
-	if contact == nil {
+	contact, err := t.getContact(id)
+	if contact == nil || err != nil {
 		return ipfs.ShortenID(id)
 	}
 	return toUsername(contact)

--- a/core/thread_announces.go
+++ b/core/thread_announces.go
@@ -72,7 +72,10 @@ func (t *Thread) handleAnnounceBlock(hash mh.Multihash, block *pb.ThreadBlock) (
 // buildAnnounce builds up a Announce block
 func (t *Thread) buildAnnounce() (*pb.ThreadAnnounce, error) {
 	msg := &pb.ThreadAnnounce{}
-	contact := t.datastore.Contacts().Get(t.node().Identity.Pretty())
+	contact, err := t.getContact(t.node().Identity.Pretty())
+	if err != nil {
+		return nil, err
+	}
 	if contact != nil {
 		msg.Contact = repoContactToProto(contact)
 	}

--- a/core/thread_joins.go
+++ b/core/thread_joins.go
@@ -102,7 +102,10 @@ func (t *Thread) buildJoin(inviterId string) (*pb.ThreadJoin, error) {
 	msg := &pb.ThreadJoin{
 		Inviter: inviterId,
 	}
-	contact := t.datastore.Contacts().Get(t.node().Identity.Pretty())
+	contact, err := t.getContact(t.node().Identity.Pretty())
+	if err != nil {
+		return nil, err
+	}
 	if contact != nil {
 		msg.Contact = repoContactToProto(contact)
 	}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@textile/go-mobile",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P.",
-  "version": "1.0.0-rc25",
+  "version": "1.0.0-rc26",
   "author": "textile.io",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "textile-go",
   "description": "Encrypted, recoverable, schema-based, cross-application data storage built on IPFS and LibP2P.",
-  "version": "1.0.0-rc25",
+  "version": "1.0.0-rc26",
   "author": "textile.io",
   "license": "MIT",
   "repository": {

--- a/repo/datastore.go
+++ b/repo/datastore.go
@@ -54,8 +54,8 @@ type ProfileStore interface {
 
 type ContactStore interface {
 	Queryable
-	Add(device *Contact) error
-	AddOrUpdate(device *Contact) error
+	Add(contact *Contact) error
+	AddOrUpdate(contact *Contact) error
 	Get(id string) *Contact
 	List() []Contact
 	ListByAddress(address string) []Contact


### PR DESCRIPTION
Exposes an internal temp contact method that checks if the given peer ID matches the local nodes,
and if so, uses profile to build a contact. This is needed by a few cases where we're trying to grab the local node's contact info.