### PR TITLE
search: fix index out of bounds when deduping results

### DIFF
--- a/core/cafe_service.go
+++ b/core/cafe_service.go
@@ -1122,6 +1122,9 @@ func (h *CafeService) setAddrs(conf *config.Config, swarmPorts config.SwarmPorts
 // keeping the most recently updated version.
 // https://github.com/golang/go/wiki/SliceTricks#in-place-deduplicate-comparable
 func deduplicateContactResults(in []*pb.Contact) []*pb.Contact {
+	if len(in) < 2 {
+		return in
+	}
 	sort.Slice(in, func(i, j int) bool {
 		return protoTimeToNano(in[i].Updated) > protoTimeToNano(in[j].Updated)
 	})


### PR DESCRIPTION
Small little fix here... I noticed this when searching and getting no results. Since we don't have search yet in the app, no need to update the framework. This fix can just come along for the ride next time.