### PR TITLE
feed: adds annotated flag for nested/not-nested annotations

### DIFF
--- a/cmd/feed.go
+++ b/cmd/feed.go
@@ -14,10 +14,11 @@ func init() {
 }
 
 type lsCmd struct {
-	Client ClientOptions `group:"Client Options"`
-	Thread string        `short:"t" long:"thread" description:"Thread ID. Omit for all."`
-	Offset string        `short:"o" long:"offset" description:"Offset ID to start listing from."`
-	Limit  int           `short:"l" long:"limit" description:"List page size." default:"5"`
+	Client    ClientOptions `group:"Client Options"`
+	Thread    string        `short:"t" long:"thread" description:"Thread ID. Omit for all."`
+	Offset    string        `short:"o" long:"offset" description:"Offset ID to start listing from."`
+	Limit     int           `short:"l" long:"limit" description:"List page size." default:"5"`
+	Annotated bool          `short:"a" long:"annotated" description:"Nest thread annotations under their targets."`
 }
 
 func (x *lsCmd) Name() string {
@@ -39,9 +40,10 @@ Specify "default" to use the default thread (if selected).
 func (x *lsCmd) Execute(args []string) error {
 	setApi(x.Client)
 	opts := map[string]string{
-		"thread": x.Thread,
-		"offset": x.Offset,
-		"limit":  strconv.Itoa(x.Limit),
+		"thread":    x.Thread,
+		"offset":    x.Offset,
+		"limit":     strconv.Itoa(x.Limit),
+		"annotated": strconv.FormatBool(x.Annotated),
 	}
 	return callLs(opts)
 }
@@ -70,8 +72,9 @@ func callLs(opts map[string]string) error {
 	}
 
 	return callLs(map[string]string{
-		"thread": opts["thread"],
-		"offset": list[len(list)-1].Block,
-		"limit":  opts["limit"],
+		"thread":    opts["thread"],
+		"offset":    list[len(list)-1].Block,
+		"limit":     opts["limit"],
+		"annotated": opts["annotated"],
 	})
 }

--- a/common/version.go
+++ b/common/version.go
@@ -4,4 +4,4 @@ package common
 var GitCommit, GitBranch, GitState, GitSummary, BuildDate string
 
 // Version is the current application's version literal
-const Version = "1.0.0-rc36"
+const Version = "1.0.0-rc37"

--- a/core/api_comments.go
+++ b/core/api_comments.go
@@ -36,7 +36,7 @@ func (a *api) addBlockComments(g *gin.Context) {
 		return
 	}
 
-	info, err := a.node.ThreadComment(*block)
+	info, err := a.node.ThreadComment(block, true)
 	if err != nil {
 		g.String(http.StatusBadRequest, err.Error())
 		return
@@ -69,7 +69,7 @@ func (a *api) getBlockComment(g *gin.Context) {
 		return
 	}
 
-	info, err := a.node.ThreadComment(*block)
+	info, err := a.node.ThreadComment(block, true)
 	if err != nil {
 		g.String(http.StatusBadRequest, err.Error())
 		return

--- a/core/api_feed.go
+++ b/core/api_feed.go
@@ -35,7 +35,7 @@ func (a *api) lsThreadFeed(g *gin.Context) {
 		}
 	}
 
-	list, err := a.node.ThreadFeed(opts["offset"], limit, threadId)
+	list, err := a.node.ThreadFeed(opts["offset"], limit, threadId, opts["annotated"] == "true")
 	if err != nil {
 		g.String(http.StatusBadRequest, err.Error())
 		return

--- a/core/api_likes.go
+++ b/core/api_likes.go
@@ -26,7 +26,7 @@ func (a *api) addBlockLikes(g *gin.Context) {
 		return
 	}
 
-	info, err := a.node.ThreadLike(*block)
+	info, err := a.node.ThreadLike(block, true)
 	if err != nil {
 		g.String(http.StatusBadRequest, err.Error())
 		return
@@ -59,7 +59,7 @@ func (a *api) getBlockLike(g *gin.Context) {
 		return
 	}
 
-	info, err := a.node.ThreadLike(*block)
+	info, err := a.node.ThreadLike(block, true)
 	if err != nil {
 		g.String(http.StatusBadRequest, err.Error())
 		return

--- a/core/api_messages.go
+++ b/core/api_messages.go
@@ -81,15 +81,7 @@ func (a *api) lsThreadMessages(g *gin.Context) {
 }
 
 func (a *api) getThreadMessages(g *gin.Context) {
-	id := g.Param("block")
-
-	block, err := a.node.Block(id)
-	if err != nil {
-		g.String(http.StatusNotFound, "block not found")
-		return
-	}
-
-	info, err := a.node.ThreadMessage(*block)
+	info, err := a.node.ThreadMessage(g.Param("block"))
 	if err != nil {
 		g.String(http.StatusBadRequest, err.Error())
 		return

--- a/core/threads_comments.go
+++ b/core/threads_comments.go
@@ -51,8 +51,9 @@ func (t *Textile) ThreadComment(block *repo.Block, annotation bool) (*ThreadComm
 	if !annotation {
 		target, err := t.threadItem(t.datastore.Blocks().Get(block.Target), false)
 		if err != nil {
-			info.Target = target
+			return nil, err
 		}
+		info.Target = target
 	}
 
 	return info, nil

--- a/core/threads_comments.go
+++ b/core/threads_comments.go
@@ -8,12 +8,13 @@ import (
 )
 
 type ThreadCommentInfo struct {
-	Id       string    `json:"id"`
-	Date     time.Time `json:"date"`
-	AuthorId string    `json:"author_id"`
-	Username string    `json:"username,omitempty"`
-	Avatar   string    `json:"avatar,omitempty"`
-	Body     string    `json:"body"`
+	Id       string          `json:"id"`
+	Date     time.Time       `json:"date"`
+	AuthorId string          `json:"author_id"`
+	Username string          `json:"username,omitempty"`
+	Avatar   string          `json:"avatar,omitempty"`
+	Body     string          `json:"body"`
+	Target   *ThreadFeedItem `json:"target"`
 }
 
 func (t *Textile) ThreadComments(target string) ([]ThreadCommentInfo, error) {
@@ -21,7 +22,7 @@ func (t *Textile) ThreadComments(target string) ([]ThreadCommentInfo, error) {
 
 	query := fmt.Sprintf("type=%d and target='%s'", repo.CommentBlock, target)
 	for _, block := range t.Blocks("", -1, query) {
-		info, err := t.ThreadComment(block)
+		info, err := t.ThreadComment(&block, true)
 		if err != nil {
 			continue
 		}
@@ -31,19 +32,28 @@ func (t *Textile) ThreadComments(target string) ([]ThreadCommentInfo, error) {
 	return comments, nil
 }
 
-func (t *Textile) ThreadComment(block repo.Block) (*ThreadCommentInfo, error) {
+func (t *Textile) ThreadComment(block *repo.Block, annotation bool) (*ThreadCommentInfo, error) {
 	if block.Type != repo.CommentBlock {
 		return nil, ErrBlockWrongType
 	}
 
 	username, avatar := t.ContactDisplayInfo(block.AuthorId)
 
-	return &ThreadCommentInfo{
+	info := &ThreadCommentInfo{
 		Id:       block.Id,
 		Date:     block.Date,
 		AuthorId: block.AuthorId,
 		Username: username,
 		Avatar:   avatar,
 		Body:     block.Body,
-	}, nil
+	}
+
+	if !annotation {
+		target, err := t.threadItem(t.datastore.Blocks().Get(block.Target), false)
+		if err != nil {
+			info.Target = target
+		}
+	}
+
+	return info, nil
 }

--- a/core/threads_feed.go
+++ b/core/threads_feed.go
@@ -95,10 +95,10 @@ func (t *Textile) threadItem(block *repo.Block, annotated bool) (*ThreadFeedItem
 		item.Message, err = t.threadMessage(block, annotated)
 	case repo.CommentBlock:
 		item.Type = CommentThreadFeedItem
-		item.Comment, err = t.ThreadComment(block, !annotated)
+		item.Comment, err = t.ThreadComment(block, annotated)
 	case repo.LikeBlock:
 		item.Type = LikeThreadFeedItem
-		item.Like, err = t.ThreadLike(block, !annotated)
+		item.Like, err = t.ThreadLike(block, annotated)
 	default:
 		return nil, nil
 	}

--- a/core/threads_feed.go
+++ b/core/threads_feed.go
@@ -14,6 +14,8 @@ const (
 	LeaveThreadFeedItem   ThreadFeedItemType = "leave"
 	FilesThreadFeedItem   ThreadFeedItemType = "files"
 	MessageThreadFeedItem ThreadFeedItemType = "message"
+	CommentThreadFeedItem ThreadFeedItemType = "comment"
+	LikeThreadFeedItem    ThreadFeedItemType = "like"
 )
 
 type ThreadFeedItem struct {
@@ -23,52 +25,85 @@ type ThreadFeedItem struct {
 	Leave   *ThreadLeaveInfo   `json:"leave,omitempty"`
 	Files   *ThreadFilesInfo   `json:"files,omitempty"`
 	Message *ThreadMessageInfo `json:"message,omitempty"`
+	Comment *ThreadCommentInfo `json:"comment,omitempty"`
+	Like    *ThreadLikeInfo    `json:"like,omitempty"`
 }
 
-func (t *Textile) ThreadFeed(offset string, limit int, threadId string) ([]ThreadFeedItem, error) {
+var feedTypes = []repo.BlockType{
+	repo.JoinBlock, repo.LeaveBlock, repo.FilesBlock, repo.MessageBlock, repo.CommentBlock, repo.LikeBlock,
+}
+
+var annotatedFeedTypes = []repo.BlockType{
+	repo.JoinBlock, repo.LeaveBlock, repo.FilesBlock, repo.MessageBlock,
+}
+
+func (t *Textile) ThreadFeed(offset string, limit int, threadId string, annotated bool) ([]ThreadFeedItem, error) {
+	var types []repo.BlockType
+	if annotated {
+		types = annotatedFeedTypes
+	} else {
+		types = feedTypes
+	}
+
 	var query string
+	for i, t := range types {
+		query += fmt.Sprintf("type=%d", t)
+		if i != len(types)-1 {
+			query += " or "
+		}
+	}
+	query = "(" + query + ")"
 	if threadId != "" {
 		if t.Thread(threadId) == nil {
 			return nil, ErrThreadNotFound
 		}
-		stm := "(threadId='%s') and (type=%d or type=%d or type=%d or type=%d)"
-		query = fmt.Sprintf(stm, threadId, repo.JoinBlock, repo.LeaveBlock, repo.FilesBlock, repo.MessageBlock)
-	} else {
-		stm := "(type=%d or type=%d or type=%d or type=%d)"
-		query = fmt.Sprintf(stm, repo.JoinBlock, repo.LeaveBlock, repo.FilesBlock, repo.MessageBlock)
+		query = fmt.Sprintf("(threadId='%s') and %s", threadId, query)
 	}
 
 	list := make([]ThreadFeedItem, 0)
 
 	blocks := t.Blocks(offset, limit, query)
 	for _, block := range blocks {
-		item := ThreadFeedItem{
-			Block: block.Id,
-		}
-		var err error
-		switch block.Type {
-		case repo.JoinBlock:
-			item.Type = JoinThreadFeedItem
-			item.Join, err = t.ThreadJoin(block)
-		case repo.LeaveBlock:
-			item.Type = LeaveThreadFeedItem
-			item.Leave, err = t.ThreadLeave(block)
-		case repo.FilesBlock:
-			item.Type = FilesThreadFeedItem
-			item.Files, err = t.threadFile(block)
-		case repo.MessageBlock:
-			item.Type = MessageThreadFeedItem
-			item.Message, err = t.ThreadMessage(block)
-		default:
-			continue
-		}
+		item, err := t.threadItem(&block, annotated)
 		if err != nil {
 			return nil, err
 		}
-		list = append(list, item)
+		list = append(list, *item)
 	}
 
 	return list, nil
+}
+
+func (t *Textile) threadItem(block *repo.Block, annotated bool) (*ThreadFeedItem, error) {
+	item := &ThreadFeedItem{
+		Block: block.Id,
+	}
+
+	var err error
+	switch block.Type {
+	case repo.JoinBlock:
+		item.Type = JoinThreadFeedItem
+		item.Join, err = t.ThreadJoin(block, annotated)
+	case repo.LeaveBlock:
+		item.Type = LeaveThreadFeedItem
+		item.Leave, err = t.ThreadLeave(block, annotated)
+	case repo.FilesBlock:
+		item.Type = FilesThreadFeedItem
+		item.Files, err = t.threadFile(block, annotated)
+	case repo.MessageBlock:
+		item.Type = MessageThreadFeedItem
+		item.Message, err = t.threadMessage(block, annotated)
+	case repo.CommentBlock:
+		item.Type = CommentThreadFeedItem
+		item.Comment, err = t.ThreadComment(block, !annotated)
+	case repo.LikeBlock:
+		item.Type = LikeThreadFeedItem
+		item.Like, err = t.ThreadLike(block, !annotated)
+	default:
+		return nil, nil
+	}
+
+	return item, err
 }
 
 type ThreadJoinInfo struct {
@@ -89,46 +124,54 @@ type ThreadLeaveInfo struct {
 	Likes    []ThreadLikeInfo `json:"likes"`
 }
 
-func (t *Textile) ThreadJoin(block repo.Block) (*ThreadJoinInfo, error) {
+func (t *Textile) ThreadJoin(block *repo.Block, annotated bool) (*ThreadJoinInfo, error) {
 	if block.Type != repo.JoinBlock {
 		return nil, ErrBlockWrongType
 	}
 
-	likes, err := t.ThreadLikes(block.Id)
-	if err != nil {
-		return nil, err
-	}
-
 	username, avatar := t.ContactDisplayInfo(block.AuthorId)
 
-	return &ThreadJoinInfo{
+	info := &ThreadJoinInfo{
 		Block:    block.Id,
 		Date:     block.Date,
 		AuthorId: block.AuthorId,
 		Username: username,
 		Avatar:   avatar,
-		Likes:    likes,
-	}, nil
+	}
+
+	if annotated {
+		likes, err := t.ThreadLikes(block.Id)
+		if err != nil {
+			return nil, err
+		}
+		info.Likes = likes
+	}
+
+	return info, nil
 }
 
-func (t *Textile) ThreadLeave(block repo.Block) (*ThreadLeaveInfo, error) {
+func (t *Textile) ThreadLeave(block *repo.Block, annotated bool) (*ThreadLeaveInfo, error) {
 	if block.Type != repo.LeaveBlock {
 		return nil, ErrBlockWrongType
 	}
 
-	likes, err := t.ThreadLikes(block.Id)
-	if err != nil {
-		return nil, err
-	}
-
 	username, avatar := t.ContactDisplayInfo(block.AuthorId)
 
-	return &ThreadLeaveInfo{
+	info := &ThreadLeaveInfo{
 		Block:    block.Id,
 		Date:     block.Date,
 		AuthorId: block.AuthorId,
 		Username: username,
 		Avatar:   avatar,
-		Likes:    likes,
-	}, nil
+	}
+
+	if annotated {
+		likes, err := t.ThreadLikes(block.Id)
+		if err != nil {
+			return nil, err
+		}
+		info.Likes = likes
+	}
+
+	return info, nil
 }

--- a/core/threads_likes.go
+++ b/core/threads_likes.go
@@ -8,11 +8,12 @@ import (
 )
 
 type ThreadLikeInfo struct {
-	Id       string    `json:"id"`
-	Date     time.Time `json:"date"`
-	AuthorId string    `json:"author_id"`
-	Username string    `json:"username,omitempty"`
-	Avatar   string    `json:"avatar,omitempty"`
+	Id       string          `json:"id"`
+	Date     time.Time       `json:"date"`
+	AuthorId string          `json:"author_id"`
+	Username string          `json:"username,omitempty"`
+	Avatar   string          `json:"avatar,omitempty"`
+	Target   *ThreadFeedItem `json:"target"`
 }
 
 func (t *Textile) ThreadLikes(target string) ([]ThreadLikeInfo, error) {
@@ -20,7 +21,7 @@ func (t *Textile) ThreadLikes(target string) ([]ThreadLikeInfo, error) {
 
 	query := fmt.Sprintf("type=%d and target='%s'", repo.LikeBlock, target)
 	for _, block := range t.Blocks("", -1, query) {
-		info, err := t.ThreadLike(block)
+		info, err := t.ThreadLike(&block, true)
 		if err != nil {
 			continue
 		}
@@ -30,18 +31,27 @@ func (t *Textile) ThreadLikes(target string) ([]ThreadLikeInfo, error) {
 	return likes, nil
 }
 
-func (t *Textile) ThreadLike(block repo.Block) (*ThreadLikeInfo, error) {
+func (t *Textile) ThreadLike(block *repo.Block, annotation bool) (*ThreadLikeInfo, error) {
 	if block.Type != repo.LikeBlock {
 		return nil, ErrBlockWrongType
 	}
 
 	username, avatar := t.ContactDisplayInfo(block.AuthorId)
 
-	return &ThreadLikeInfo{
+	info := &ThreadLikeInfo{
 		Id:       block.Id,
 		Date:     block.Date,
 		AuthorId: block.AuthorId,
 		Username: username,
 		Avatar:   avatar,
-	}, nil
+	}
+
+	if !annotation {
+		target, err := t.threadItem(t.datastore.Blocks().Get(block.Target), false)
+		if err != nil {
+			info.Target = target
+		}
+	}
+
+	return info, nil
 }

--- a/core/threads_likes.go
+++ b/core/threads_likes.go
@@ -49,8 +49,9 @@ func (t *Textile) ThreadLike(block *repo.Block, annotation bool) (*ThreadLikeInf
 	if !annotation {
 		target, err := t.threadItem(t.datastore.Blocks().Get(block.Target), false)
 		if err != nil {
-			info.Target = target
+			return nil, err
 		}
+		info.Target = target
 	}
 
 	return info, nil

--- a/mobile/feed.go
+++ b/mobile/feed.go
@@ -8,7 +8,7 @@ func (m *Mobile) ThreadFeed(offset string, limit int, threadId string) (string, 
 		return "", core.ErrStopped
 	}
 
-	items, err := m.node.ThreadFeed(offset, limit, threadId)
+	items, err := m.node.ThreadFeed(offset, limit, threadId, false)
 	if err != nil {
 		return "", err
 	}

--- a/mobile/feed.go
+++ b/mobile/feed.go
@@ -3,12 +3,12 @@ package mobile
 import "github.com/textileio/textile-go/core"
 
 // ThreadFeed calls core ThreadFeed
-func (m *Mobile) ThreadFeed(offset string, limit int, threadId string) (string, error) {
+func (m *Mobile) ThreadFeed(offset string, limit int, threadId string, annotated bool) (string, error) {
 	if !m.node.Started() {
 		return "", core.ErrStopped
 	}
 
-	items, err := m.node.ThreadFeed(offset, limit, threadId, false)
+	items, err := m.node.ThreadFeed(offset, limit, threadId, annotated)
 	if err != nil {
 		return "", err
 	}

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -456,7 +456,7 @@ func TestMobile_AddThreadIgnore(t *testing.T) {
 }
 
 func TestMobile_ThreadFeed(t *testing.T) {
-	res, err := mobile1.ThreadFeed("", -1, thrdId)
+	res, err := mobile1.ThreadFeed("", -1, thrdId, false)
 	if err != nil {
 		t.Errorf("get thread feed failed: %s", err)
 		return

--- a/mobile/mobile_test.go
+++ b/mobile/mobile_test.go
@@ -466,7 +466,7 @@ func TestMobile_ThreadFeed(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if len(feed) != 3 {
+	if len(feed) != 5 {
 		t.Errorf("get thread feed bad result")
 	}
 }

--- a/mobile/search.go
+++ b/mobile/search.go
@@ -6,11 +6,13 @@ import (
 	"github.com/textileio/textile-go/pb"
 )
 
+// CancelFn is used to cancel an async request
 type CancelFn struct {
 	cancel *broadcast.Broadcaster
 	done   func()
 }
 
+// Call is used to invoke the cancel
 func (c *CancelFn) Call() {
 	c.cancel.Close()
 	c.done()


### PR DESCRIPTION
Take a look at this @asutula - basically, adds a flag that dictated whether or not annotations (comments/likes) are nested underneath their targets or listed at the top level. If they're listed at the top level, their `target` field is populated w/ another feed item object which is the thing that comment/like is about.