### PR TITLE
Include src in package files list

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -25,7 +25,8 @@
     "android"
   ],
   "files": [
-    "scripts"
+    "scripts",
+    "src"
   ],
   "scripts": {
     "postinstall": "./scripts/fetch_release.sh $npm_package_version"


### PR DESCRIPTION
For some reason, `mobile/src/index.d.ts` isn't getting included in the npm module. Strangely, `mobile/src/index.js` is. I'm not sure this will fix it, but hoping so. Ideas @sanderpick?